### PR TITLE
Add adapter SDK with PlaybackAdapter and YouTubeEmbedAdapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,9 @@ and map database utilities.
 
 ```
 schema/              # TypeScript type definitions for map format
+sdk/
+  adapters/          # PlaybackAdapter interface + reference implementations
+sdk/index.ts         # SDK entry point (re-exports)
 src/
   bootstrap/         # Map generation pipeline (audio → map JSON)
   db/                # SQLite map database utilities
@@ -60,6 +63,25 @@ Maps are JSON files describing the structure of a recording:
 - Provenance for analyzed fields tracked in top-level `analysis` field
 - `playback` lists known platforms with structured capability objects
 - `metadata.extra` extends typed fields using MusicBrainz Picard tag keys
+
+### Adapter SDK
+
+Reference playback adapters for common platforms. Any player can
+import these directly. The protocol defines `PlaybackCapabilities`
+as a catalog of what platforms can do; the SDK provides ready-to-use
+implementations.
+
+- **Interface:** `PlaybackAdapter` in `sdk/adapters/types.ts`
+- **Registry:** `createRegistry()` resolves URLs to platform + source ID
+- **Adapters:** `YouTubeEmbedAdapter` (iframe API, web + iPad)
+- **Volume:** Normalized 0–1 across all adapters
+- **State events:** `onStateChange()` for discrete transitions;
+  `getPosition()` for polling
+- **Capabilities:** Each adapter exposes a `capabilities` object
+  matching `PlaybackCapabilities` from the schema
+
+Players can use SDK adapters directly, extend them, or build their
+own adapter contract. Community-contributed adapters accepted via PR.
 
 ### Bootstrap pipeline
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.0",
   "description": "An open-source protocol for mapping time-based media and layering synchronized experiences on top.",
   "type": "module",
+  "exports": {
+    "./sdk": "./sdk/index.ts",
+    "./sdk/adapters": "./sdk/adapters/index.ts",
+    "./schema": "./schema/map.ts"
+  },
   "scripts": {
     "bootstrap": "bun run src/bootstrap/cli.ts",
     "lint": "biome check .",

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,0 +1,104 @@
+# PulseMap Adapter SDK
+
+Reference playback adapters for the PulseMap protocol. Use these to build players that consume PulseMap files.
+
+## Quick start
+
+```typescript
+import {
+  YouTubeEmbedAdapter,
+  youTubeEmbedMatcher,
+  createRegistry,
+} from "pulsemap/sdk";
+
+// Resolve a URL to a platform
+const registry = createRegistry([youTubeEmbedMatcher]);
+const result = registry.resolve("https://youtube.com/watch?v=abc123");
+// { platform: "youtube", sourceId: "abc123" }
+
+// Create an adapter
+const adapter = new YouTubeEmbedAdapter({
+  elementId: "player",
+  videoId: result.sourceId,
+});
+
+await adapter.waitForReady();
+adapter.play();
+
+// Poll for position
+setInterval(() => {
+  console.log(adapter.getPosition()); // ms
+}, 50);
+
+// React to state changes
+adapter.onStateChange((state) => {
+  console.log(state); // "playing", "paused", "ended", etc.
+});
+
+// Check capabilities before using optional features
+if (adapter.capabilities.volume) {
+  adapter.setVolume(0.5); // 0-1 normalized
+}
+```
+
+## PlaybackAdapter interface
+
+Every adapter implements `PlaybackAdapter`:
+
+| Method | Description |
+|--------|-------------|
+| `waitForReady()` | Resolves when the adapter can accept commands |
+| `getPosition()` | Current position in milliseconds |
+| `seek(ms)` | Move playhead to position |
+| `play()` / `pause()` | Control playback |
+| `isPlaying()` | Whether media is currently playing |
+| `getState()` | Current state: `unstarted`, `playing`, `paused`, `buffering`, `ended` |
+| `getPlaybackRate()` / `setPlaybackRate(rate)` | Speed control |
+| `getVolume()` / `setVolume(level)` | Volume (0-1 normalized) |
+| `isMuted()` / `setMuted(muted)` | Mute control |
+| `onStateChange(callback)` | Subscribe to state transitions; returns unsubscribe function |
+| `capabilities` | `PlaybackCapabilities` object declaring what this adapter supports |
+| `destroy()` | Release all resources |
+
+## Adapter registry
+
+The registry resolves URLs to the platform that can handle them:
+
+```typescript
+const registry = createRegistry([youTubeEmbedMatcher]);
+registry.register(myCustomMatcher); // add more at runtime
+
+const result = registry.resolve(url);
+if (result) {
+  // result.platform, result.sourceId
+}
+```
+
+## Building a custom adapter
+
+Implement `PlaybackAdapter` and provide an `AdapterMatcher`:
+
+```typescript
+import type { PlaybackAdapter, AdapterMatcher } from "pulsemap/sdk";
+
+export const myMatcher: AdapterMatcher = {
+  platform: "my-platform",
+  match(url: string): string | null {
+    // return source ID if this URL is yours, null otherwise
+  },
+};
+
+export class MyAdapter implements PlaybackAdapter {
+  readonly platform = "my-platform";
+  readonly capabilities = { play: true, pause: true, getPosition: true };
+  // ... implement the interface
+}
+```
+
+Contributions welcome — if your adapter works well, consider opening a PR to add it to the SDK.
+
+## Available adapters
+
+| Adapter | Platform | Environment |
+|---------|----------|-------------|
+| `YouTubeEmbedAdapter` | YouTube | Browser (iframe API) |

--- a/sdk/adapters/index.ts
+++ b/sdk/adapters/index.ts
@@ -1,0 +1,9 @@
+export type { AdapterMatcher, PlaybackAdapter, PlaybackState } from "./types";
+export { createRegistry } from "./registry";
+export type { AdapterRegistry, ResolveResult } from "./registry";
+export {
+	parseYouTubeVideoId,
+	YouTubeEmbedAdapter,
+	youTubeEmbedMatcher,
+} from "./youtube-embed";
+export type { YouTubeEmbedOptions } from "./youtube-embed";

--- a/sdk/adapters/registry.ts
+++ b/sdk/adapters/registry.ts
@@ -1,0 +1,40 @@
+import type { AdapterMatcher } from "./types";
+
+/**
+ * Resolves a URL to the platform and source ID that can handle it.
+ * Returns null if no registered matcher recognizes the URL.
+ *
+ * Usage:
+ *   const registry = createRegistry([youTubeEmbedMatcher]);
+ *   const result = registry.resolve("https://youtube.com/watch?v=abc");
+ *   // { platform: "youtube", sourceId: "abc" }
+ */
+export interface ResolveResult {
+	platform: string;
+	sourceId: string;
+}
+
+export interface AdapterRegistry {
+	resolve(url: string): ResolveResult | null;
+	register(matcher: AdapterMatcher): void;
+}
+
+export function createRegistry(matchers: AdapterMatcher[] = []): AdapterRegistry {
+	const registered = [...matchers];
+
+	return {
+		resolve(url: string): ResolveResult | null {
+			for (const matcher of registered) {
+				const sourceId = matcher.match(url);
+				if (sourceId !== null) {
+					return { platform: matcher.platform, sourceId };
+				}
+			}
+			return null;
+		},
+
+		register(matcher: AdapterMatcher) {
+			registered.push(matcher);
+		},
+	};
+}

--- a/sdk/adapters/types.ts
+++ b/sdk/adapters/types.ts
@@ -1,0 +1,78 @@
+import type { PlaybackCapabilities } from "../../schema/map";
+
+/**
+ * Playback states an adapter can report.
+ *
+ * "unstarted" is the initial state before any media has played.
+ * "ended" means playback reached the end of the media.
+ * "buffering" means the adapter is loading data and cannot
+ * report a reliable position.
+ */
+export type PlaybackState = "unstarted" | "playing" | "paused" | "buffering" | "ended";
+
+/**
+ * Common interface for controlling playback across platforms.
+ *
+ * The protocol defines PlaybackCapabilities as a catalog of what
+ * platforms can do. This interface is the SDK's implementation of
+ * that catalog — a common surface that players can program against
+ * without knowing which platform is underneath.
+ *
+ * Not every adapter supports every method. Check `capabilities`
+ * before calling optional methods (volume, mute, rate). Methods
+ * for unsupported capabilities are safe to call but will no-op.
+ *
+ * Volume is normalized to 0–1. Adapters convert to/from the
+ * platform's native range internally.
+ */
+export interface PlaybackAdapter {
+	readonly platform: string;
+	readonly capabilities: PlaybackCapabilities;
+
+	/** Resolves when the adapter is ready to accept commands. */
+	waitForReady(): Promise<void>;
+
+	/** Current playback position in milliseconds. */
+	getPosition(): number;
+
+	/** Move the playhead to the given position in milliseconds. */
+	seek(ms: number): void;
+
+	play(): void;
+	pause(): void;
+	isPlaying(): boolean;
+	getState(): PlaybackState;
+
+	getPlaybackRate(): number;
+	setPlaybackRate(rate: number): void;
+
+	/** Volume as a float from 0 (silent) to 1 (max). */
+	getVolume(): number;
+
+	/** Set volume as a float from 0 (silent) to 1 (max). */
+	setVolume(level: number): void;
+
+	isMuted(): boolean;
+	setMuted(muted: boolean): void;
+
+	/**
+	 * Subscribe to playback state changes. Returns an unsubscribe
+	 * function. Listeners fire on discrete transitions (play, pause,
+	 * ended, buffering), not on every position tick.
+	 */
+	onStateChange(callback: (state: PlaybackState) => void): () => void;
+
+	/** Release all resources. The adapter is unusable after this. */
+	destroy(): void;
+}
+
+/**
+ * A function that checks whether a URL belongs to a given platform
+ * and extracts the platform-specific ID if so. Used by the adapter
+ * registry to resolve URLs to the correct adapter before
+ * construction.
+ */
+export interface AdapterMatcher {
+	readonly platform: string;
+	match(url: string): string | null;
+}

--- a/sdk/adapters/youtube-embed.ts
+++ b/sdk/adapters/youtube-embed.ts
@@ -1,0 +1,254 @@
+import type { PlaybackCapabilities } from "../../schema/map";
+import type { AdapterMatcher, PlaybackAdapter, PlaybackState } from "./types";
+
+declare namespace YT {
+	enum PlayerState {
+		UNSTARTED = -1,
+		ENDED = 0,
+		PLAYING = 1,
+		PAUSED = 2,
+		BUFFERING = 3,
+		CUED = 5,
+	}
+
+	interface PlayerOptions {
+		width?: number | string;
+		height?: number | string;
+		videoId?: string;
+		playerVars?: Record<string, unknown>;
+		events?: {
+			onReady?: (event: { target: Player }) => void;
+			onStateChange?: (event: { data: PlayerState }) => void;
+			onError?: (event: { data: number }) => void;
+		};
+	}
+
+	class Player {
+		constructor(elementId: string | HTMLElement, options: PlayerOptions);
+		playVideo(): void;
+		pauseVideo(): void;
+		seekTo(seconds: number, allowSeekAhead?: boolean): void;
+		getCurrentTime(): number;
+		getDuration(): number;
+		getPlayerState(): PlayerState;
+		setPlaybackRate(rate: number): void;
+		getPlaybackRate(): number;
+		getAvailablePlaybackRates(): number[];
+		getVolume(): number;
+		setVolume(volume: number): void;
+		isMuted(): boolean;
+		mute(): void;
+		unMute(): void;
+		getVideoData(): { video_id: string; title: string; author: string };
+		destroy(): void;
+	}
+}
+
+interface YTWindow {
+	onYouTubeIframeAPIReady?: () => void;
+	YT?: typeof YT;
+}
+
+let apiLoaded = false;
+let apiReady = false;
+const apiReadyCallbacks: (() => void)[] = [];
+
+function ensureApi(): Promise<void> {
+	if (apiReady) return Promise.resolve();
+	return new Promise<void>((resolve) => {
+		apiReadyCallbacks.push(resolve);
+		if (apiLoaded) return;
+		apiLoaded = true;
+		const tag = document.createElement("script");
+		tag.src = "https://www.youtube.com/iframe_api";
+		document.head.appendChild(tag);
+		(window as YTWindow).onYouTubeIframeAPIReady = () => {
+			apiReady = true;
+			for (const cb of apiReadyCallbacks) cb();
+			apiReadyCallbacks.length = 0;
+		};
+	});
+}
+
+function ytStateToPlaybackState(state: YT.PlayerState): PlaybackState {
+	switch (state) {
+		case YT.PlayerState.PLAYING:
+			return "playing";
+		case YT.PlayerState.PAUSED:
+			return "paused";
+		case YT.PlayerState.BUFFERING:
+			return "buffering";
+		case YT.PlayerState.ENDED:
+			return "ended";
+		default:
+			return "unstarted";
+	}
+}
+
+/**
+ * Extract a YouTube video ID from a URL. Returns null if the URL
+ * is not a recognized YouTube format.
+ */
+export function parseYouTubeVideoId(url: string): string | null {
+	try {
+		const u = new URL(url);
+		if (u.hostname === "youtu.be") return u.pathname.slice(1) || null;
+		if (u.hostname.includes("youtube.com")) return u.searchParams.get("v");
+	} catch {
+		// not a valid URL
+	}
+	return null;
+}
+
+export const youTubeEmbedMatcher: AdapterMatcher = {
+	platform: "youtube",
+	match: parseYouTubeVideoId,
+};
+
+export interface YouTubeEmbedOptions {
+	elementId: string;
+	videoId: string;
+	playerVars?: Record<string, unknown>;
+}
+
+const YOUTUBE_CAPABILITIES: PlaybackCapabilities = {
+	play: true,
+	pause: true,
+	seek: true,
+	setPosition: true,
+	getPosition: true,
+	rate: [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2],
+	volume: true,
+	mute: true,
+};
+
+export class YouTubeEmbedAdapter implements PlaybackAdapter {
+	readonly platform = "youtube";
+	readonly capabilities: PlaybackCapabilities = YOUTUBE_CAPABILITIES;
+
+	private player: YT.Player | null = null;
+	private ready = false;
+	private readyPromise: Promise<void>;
+	private resolveReady!: () => void;
+	private stateListeners = new Set<(state: PlaybackState) => void>();
+	private currentState: PlaybackState = "unstarted";
+
+	constructor(private options: YouTubeEmbedOptions) {
+		this.readyPromise = new Promise<void>((resolve) => {
+			this.resolveReady = resolve;
+		});
+		this.init();
+	}
+
+	private async init() {
+		await ensureApi();
+		this.player = new YT.Player(this.options.elementId, {
+			videoId: this.options.videoId,
+			playerVars: {
+				autoplay: 0,
+				controls: 1,
+				modestbranding: 1,
+				rel: 0,
+				playsinline: 1,
+				...this.options.playerVars,
+			},
+			events: {
+				onReady: () => {
+					this.ready = true;
+					this.resolveReady();
+				},
+				onStateChange: (event) => {
+					const newState = ytStateToPlaybackState(event.data);
+					if (newState !== this.currentState) {
+						this.currentState = newState;
+						for (const listener of this.stateListeners) {
+							listener(newState);
+						}
+					}
+				},
+			},
+		});
+	}
+
+	waitForReady(): Promise<void> {
+		return this.readyPromise;
+	}
+
+	getPosition(): number {
+		if (!this.ready || !this.player) return 0;
+		return this.player.getCurrentTime() * 1000;
+	}
+
+	seek(ms: number): void {
+		if (!this.ready || !this.player) return;
+		this.player.seekTo(ms / 1000, true);
+	}
+
+	play(): void {
+		if (!this.ready || !this.player) return;
+		this.player.playVideo();
+	}
+
+	pause(): void {
+		if (!this.ready || !this.player) return;
+		this.player.pauseVideo();
+	}
+
+	isPlaying(): boolean {
+		if (!this.ready || !this.player) return false;
+		return this.player.getPlayerState() === YT.PlayerState.PLAYING;
+	}
+
+	getState(): PlaybackState {
+		return this.currentState;
+	}
+
+	getPlaybackRate(): number {
+		if (!this.ready || !this.player) return 1;
+		return this.player.getPlaybackRate();
+	}
+
+	setPlaybackRate(rate: number): void {
+		if (!this.ready || !this.player) return;
+		this.player.setPlaybackRate(rate);
+	}
+
+	getVolume(): number {
+		if (!this.ready || !this.player) return 1;
+		return this.player.getVolume() / 100;
+	}
+
+	setVolume(level: number): void {
+		if (!this.ready || !this.player) return;
+		this.player.setVolume(Math.round(level * 100));
+	}
+
+	isMuted(): boolean {
+		if (!this.ready || !this.player) return false;
+		return this.player.isMuted();
+	}
+
+	setMuted(muted: boolean): void {
+		if (!this.ready || !this.player) return;
+		if (muted) this.player.mute();
+		else this.player.unMute();
+	}
+
+	onStateChange(callback: (state: PlaybackState) => void): () => void {
+		this.stateListeners.add(callback);
+		return () => this.stateListeners.delete(callback);
+	}
+
+	/** YouTube-specific: get the video title from the player. */
+	getVideoTitle(): string {
+		if (!this.ready || !this.player) return "";
+		return this.player.getVideoData().title;
+	}
+
+	destroy(): void {
+		this.player?.destroy();
+		this.player = null;
+		this.ready = false;
+		this.stateListeners.clear();
+	}
+}

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -1,0 +1,8 @@
+export type { AdapterMatcher, AdapterRegistry, PlaybackAdapter, PlaybackState } from "./adapters";
+export {
+	createRegistry,
+	parseYouTubeVideoId,
+	YouTubeEmbedAdapter,
+	youTubeEmbedMatcher,
+} from "./adapters";
+export type { ResolveResult, YouTubeEmbedOptions } from "./adapters";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "outDir": "dist",
     "types": ["bun"]
   },
-  "include": ["src/**/*.ts", "schema/**/*.ts"],
+  "include": ["src/**/*.ts", "schema/**/*.ts", "sdk/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- New `sdk/adapters/` directory with `PlaybackAdapter` interface and `YouTubeEmbedAdapter` reference implementation
- Interface changes from pulseguide's original: collapsed `seek`/`setPosition` into `seek`, removed instance `canHandle` in favor of registry/matcher pattern, added `waitForReady()`, `onStateChange()` events, `capabilities` object, `getState()`, volume normalized 0-1
- Adapter registry resolves URLs to platform + source ID before adapter construction
- SDK README with quick start, interface reference, and guide for building custom adapters
- Package exports added: `pulsemap/sdk`, `pulsemap/sdk/adapters`, `pulsemap/schema`
- CLAUDE.md updated with SDK documentation

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [x] Verified by pulseguide consuming the SDK (see hartphoenix/pulseguide adapter-migration branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)