### PR TITLE
Fix Genius API timeout (5s → 30s)

### DIFF
--- a/src/bootstrap/scripts/fetch_genius_sections.py
+++ b/src/bootstrap/scripts/fetch_genius_sections.py
@@ -38,6 +38,8 @@ def main():
     genius = lyricsgenius.Genius(token)
     genius.verbose = False
     genius.remove_section_headers = False
+    genius.timeout = 30
+    genius.retries = 2
 
     song = genius.search_song(title, artist)
     if not song or not song.lyrics:


### PR DESCRIPTION
## Summary
- Increase lyricsgenius timeout from 5s default to 30s
- Add 2 retries for transient failures
- Fixes consistent timeout during pipeline runs

## Test plan
- [ ] Re-run batch pipeline with GENIUS_API_TOKEN set

🤖 Generated with [Claude Code](https://claude.com/claude-code)