### PR TITLE
feat(schema+sdk): add corrections field, move parsePlaybackTarget, add editor module

### DIFF
--- a/schema/map.ts
+++ b/schema/map.ts
@@ -173,6 +173,15 @@ export const SectionSchema = Type.Object({
 });
 export type Section = Static<typeof SectionSchema>;
 
+export const CorrectionEntrySchema = Type.Object({
+	field: Type.String({ description: "Which map field was corrected." }),
+	user: Type.String({ description: "GitHub username of the contributor." }),
+	pr: Type.Number({ description: "PR number in the pulsemap repo." }),
+	date: Type.String({ description: "ISO 8601 date when the correction was merged." }),
+	edits: Type.Number({ description: "Number of individual changes to this field." }),
+});
+export type CorrectionEntry = Static<typeof CorrectionEntrySchema>;
+
 export const PulseMapSchema = Type.Object({
 	version: Type.String({ description: "Schema version (semver)." }),
 	id: Type.String({ description: "MusicBrainz recording ID." }),
@@ -189,5 +198,6 @@ export const PulseMapSchema = Type.Object({
 	sections: Type.Optional(Type.Array(SectionSchema)),
 	midi: Type.Optional(Type.Array(MidiReferenceSchema)),
 	analysis: Type.Optional(Type.Record(Type.String(), AnalysisProvenanceSchema)),
+	corrections: Type.Optional(Type.Array(CorrectionEntrySchema)),
 });
 export type PulseMap = Static<typeof PulseMapSchema>;

--- a/sdk/editor/index.ts
+++ b/sdk/editor/index.ts
@@ -1,0 +1,18 @@
+import type { EditorTarget } from "./types";
+
+const EDITOR_BASE_URL = "https://hartphoenix.github.io/pulsemap/editor";
+
+export function openEditor(target: EditorTarget): void {
+	window.open(editorUrl(target), "_blank");
+}
+
+export function editorUrl(target: EditorTarget): string {
+	const url = new URL(`${EDITOR_BASE_URL}/${target.mapId}`);
+	if (target.t !== undefined) url.searchParams.set("t", String(target.t));
+	if (target.lane) url.searchParams.set("lane", target.lane);
+	if (target.index !== undefined) url.searchParams.set("index", String(target.index));
+	if (target.source) url.searchParams.set("source", target.source);
+	return url.toString();
+}
+
+export type { EditorTarget };

--- a/sdk/editor/types.ts
+++ b/sdk/editor/types.ts
@@ -1,0 +1,7 @@
+export interface EditorTarget {
+	mapId: string;
+	t?: number;
+	lane?: "chords" | "words" | "lyrics" | "sections" | "metadata" | "playback";
+	index?: number;
+	source?: string;
+}

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -6,3 +6,6 @@ export {
 	youTubeEmbedMatcher,
 } from "./adapters";
 export type { ResolveResult, YouTubeEmbedOptions } from "./adapters";
+export { parsePlaybackTarget } from "./playback";
+export { editorUrl, openEditor } from "./editor";
+export type { EditorTarget } from "./editor";

--- a/sdk/playback.ts
+++ b/sdk/playback.ts
@@ -1,0 +1,54 @@
+import type { PlaybackTarget } from "../schema/map";
+
+export function parsePlaybackTarget(url: string): PlaybackTarget | undefined {
+	try {
+		const parsed = new URL(url);
+
+		if (parsed.hostname.includes("youtube.com") || parsed.hostname.includes("youtu.be")) {
+			const videoId = parsed.hostname.includes("youtu.be")
+				? parsed.pathname.slice(1)
+				: parsed.searchParams.get("v");
+
+			return {
+				platform: "youtube",
+				uri: url,
+				id: videoId || undefined,
+				capabilities: {
+					play: true,
+					pause: true,
+					seek: true,
+					setPosition: true,
+					getPosition: true,
+					rate: [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2],
+					volume: true,
+					mute: true,
+				},
+			};
+		}
+
+		if (parsed.hostname.includes("spotify.com")) {
+			const trackMatch = parsed.pathname.match(/track\/(\w+)/);
+			return {
+				platform: "spotify",
+				uri: url,
+				id: trackMatch?.[1],
+				capabilities: {
+					play: true,
+					pause: true,
+					seek: true,
+					setPosition: true,
+					getPosition: true,
+					volume: true,
+				},
+			};
+		}
+
+		return {
+			platform: parsed.hostname,
+			uri: url,
+			capabilities: {},
+		};
+	} catch {
+		return undefined;
+	}
+}

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -1,12 +1,7 @@
 import { copyFile, mkdir } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import type {
-	AnalysisProvenance,
-	MidiReference,
-	PlaybackTarget,
-	PulseMap,
-	WordEvent,
-} from "../../schema/map";
+import type { AnalysisProvenance, MidiReference, PulseMap, WordEvent } from "../../schema/map";
+import { parsePlaybackTarget } from "../../sdk/playback";
 import { assertValid } from "../validate";
 import { PipelineLogger } from "./logger";
 import { analyzeAudio } from "./stages/analyze";
@@ -611,58 +606,5 @@ export async function bootstrap(source: string, options: BootstrapOptions = {}):
 			stderr: "ignore",
 		});
 		await proc.exited;
-	}
-}
-
-function parsePlaybackTarget(url: string): PlaybackTarget | undefined {
-	try {
-		const parsed = new URL(url);
-
-		if (parsed.hostname.includes("youtube.com") || parsed.hostname.includes("youtu.be")) {
-			const videoId = parsed.hostname.includes("youtu.be")
-				? parsed.pathname.slice(1)
-				: parsed.searchParams.get("v");
-
-			return {
-				platform: "youtube",
-				uri: url,
-				id: videoId || undefined,
-				capabilities: {
-					play: true,
-					pause: true,
-					seek: true,
-					setPosition: true,
-					getPosition: true,
-					rate: [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2],
-					volume: true,
-					mute: true,
-				},
-			};
-		}
-
-		if (parsed.hostname.includes("spotify.com")) {
-			const trackMatch = parsed.pathname.match(/track\/(\w+)/);
-			return {
-				platform: "spotify",
-				uri: url,
-				id: trackMatch?.[1],
-				capabilities: {
-					play: true,
-					pause: true,
-					seek: true,
-					setPosition: true,
-					getPosition: true,
-					volume: true,
-				},
-			};
-		}
-
-		return {
-			platform: parsed.hostname,
-			uri: url,
-			capabilities: {},
-		};
-	} catch {
-		return undefined;
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export type {
 	ChordEvent,
 	SectionType,
 	Section,
+	CorrectionEntry,
 } from "../schema/map";
 
 export {
@@ -32,6 +33,7 @@ export {
 	ChordEventSchema,
 	SectionSchema,
 	SECTION_TYPES,
+	CorrectionEntrySchema,
 } from "../schema/map";
 
 export { validate, assertValid } from "./validate";

--- a/test/sdk-editor.test.ts
+++ b/test/sdk-editor.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import { editorUrl } from "../sdk/editor";
+
+describe("editorUrl", () => {
+	it("constructs correct URL with all params", () => {
+		const url = editorUrl({
+			mapId: "abc123",
+			t: 5000,
+			lane: "chords",
+			index: 2,
+			source: "lrclib",
+		});
+		expect(url).toBe(
+			"https://hartphoenix.github.io/pulsemap/editor/abc123?t=5000&lane=chords&index=2&source=lrclib",
+		);
+	});
+
+	it("omits undefined optional params", () => {
+		const url = editorUrl({
+			mapId: "abc123",
+			lane: "words",
+		});
+		expect(url).toBe("https://hartphoenix.github.io/pulsemap/editor/abc123?lane=words");
+		expect(url).not.toContain("t=");
+		expect(url).not.toContain("index=");
+		expect(url).not.toContain("source=");
+	});
+
+	it("works with only mapId (no optional params)", () => {
+		const url = editorUrl({ mapId: "12345678-1234-1234-1234-123456789012" });
+		expect(url).toBe(
+			"https://hartphoenix.github.io/pulsemap/editor/12345678-1234-1234-1234-123456789012",
+		);
+	});
+});

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -233,6 +233,42 @@ describe("minLength constraints", () => {
 	});
 });
 
+describe("corrections field", () => {
+	it("accepts a map with a valid corrections array", () => {
+		const map = {
+			...MINIMAL_MAP,
+			corrections: [
+				{
+					field: "chords",
+					user: "hartphoenix",
+					pr: 42,
+					date: "2026-04-28",
+					edits: 3,
+				},
+			],
+		};
+		expect(validate(map).valid).toBe(true);
+	});
+
+	it("accepts a map without corrections (optional field)", () => {
+		const result = validate(MINIMAL_MAP);
+		expect(result.valid).toBe(true);
+	});
+
+	it("rejects a correction entry with missing required fields", () => {
+		const map = {
+			...MINIMAL_MAP,
+			corrections: [
+				{
+					field: "chords",
+					// missing user, pr, date, edits
+				},
+			],
+		};
+		expect(validate(map).valid).toBe(false);
+	});
+});
+
 describe("existing map files", () => {
 	const mapsDir = join(import.meta.dir, "../maps");
 	const files = readdirSync(mapsDir).filter((f) => f.endsWith(".json"));


### PR DESCRIPTION
## Summary

- **Part 1 (B1):** Add `CorrectionEntry` schema + optional `corrections[]` array to `PulseMap`. Tracks community edits per field with contributor, PR number, date, and edit count. Exported from `src/index.ts`.
- **Part 2 (B2):** Move `parsePlaybackTarget()` from `src/bootstrap/index.ts` into `sdk/playback.ts`. Bootstrap now imports from the SDK. Makes the parser available to any consumer, not just the pipeline.
- **Part 3 (B3):** New `sdk/editor/` module with `editorUrl()` and `openEditor()` for constructing editor deep-links. `EditorTarget` interface supports mapId, time offset, lane, element index, and source param.

## Test plan

- [ ] `bun test` — 64 tests pass (3 new corrections schema tests, 3 new sdk-editor tests)
- [ ] `bun run typecheck` — no errors
- [ ] `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)