### PR TITLE
feat(pipeline): expressive vocal MIDI with pitch bend, RMS velocity, pitch-derivative segmentation

### DIFF
--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -548,7 +548,11 @@ export async function bootstrap(source: string, options: BootstrapOptions = {}):
 				const label = ref.tracks?.[0]?.label;
 				if (label) {
 					const tool =
-						label === "vocals" ? "torchcrepe" : label === "drums" ? "librosa" : "basic-pitch";
+						label === "vocals"
+							? "torchcrepe+expressive"
+							: label === "drums"
+								? "librosa"
+								: "basic-pitch";
 					provenance[`midi-${label}`] = { tool, date: today };
 				}
 			}

--- a/src/bootstrap/scripts/transcribe_pitched.py
+++ b/src/bootstrap/scripts/transcribe_pitched.py
@@ -47,6 +47,7 @@ def main():
             onset_threshold=onset_threshold,
             frame_threshold=frame_threshold,
             minimum_note_length=minimum_note_length,
+            multiple_pitch_bends=True,
         )
 
         midi_data.write(output_path)

--- a/src/bootstrap/scripts/transcribe_vocals.py
+++ b/src/bootstrap/scripts/transcribe_vocals.py
@@ -21,12 +21,13 @@ def main():
         import torch
         import torchcrepe
         import torchaudio
-        from pretty_midi import PrettyMIDI, Instrument, Note
+        from pretty_midi import PrettyMIDI, Instrument, Note, PitchBend, ControlChange
         import numpy as np
+        from scipy.ndimage import median_filter
     except ImportError as e:
         print(f"Missing dependency: {e}", file=sys.stderr)
         print(
-            "Install with: pip install torchcrepe torchaudio pretty_midi numpy",
+            "Install with: pip install torchcrepe torchaudio pretty_midi numpy scipy",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -60,56 +61,118 @@ def main():
         pitch = pitch.squeeze().cpu().numpy()
         periodicity = periodicity.squeeze().cpu().numpy()
 
+        # --- RMS velocity ---
+        # Compute per-frame RMS using hop-aligned windows on the raw waveform.
+        audio_np = audio.squeeze().cpu().numpy()
+        n_frames = len(pitch)
+        rms = np.zeros(n_frames, dtype=np.float32)
+        for i in range(n_frames):
+            start_sample = i * hop_length
+            end_sample = min(start_sample + hop_length, len(audio_np))
+            frame = audio_np[start_sample:end_sample]
+            rms[i] = np.sqrt(np.mean(frame ** 2)) if len(frame) > 0 else 0.0
+
+        max_rms = np.percentile(rms[rms > 0], 95) if np.any(rms > 0) else 1.0
+        max_rms = max(max_rms, 1e-8)
+
+        def rms_to_velocity(frame_rms_values):
+            mean_rms = np.mean(frame_rms_values) if len(frame_rms_values) > 0 else 0.0
+            v = np.sqrt(mean_rms / max_rms) * 127.0
+            return int(np.clip(round(v), 1, 127))
+
+        # --- Pitch-derivative segmentation helpers ---
         confidence_threshold = 0.5
         min_note_duration_ms = 60
+        # 80-100 cents per hop = 0.8-1.0 semitones — use 0.9 as threshold
+        pitch_derivative_threshold = 0.9  # semitones per hop
+
+        hop_sec = hop_length / sr
+
+        # Convert pitch to MIDI pitch array; set unvoiced frames to NaN
+        midi_pitch_raw = np.where(
+            (periodicity >= confidence_threshold) & (pitch > 0),
+            12.0 * np.log2(np.maximum(pitch, 1e-8) / 440.0) + 69.0,
+            np.nan,
+        )
+
+        # Compute |df0/dt| in semitones per hop, median-filtered over 5 frames
+        voiced = ~np.isnan(midi_pitch_raw)
+        pitch_deriv = np.zeros(n_frames, dtype=np.float32)
+        for i in range(1, n_frames):
+            if voiced[i] and voiced[i - 1]:
+                pitch_deriv[i] = abs(midi_pitch_raw[i] - midi_pitch_raw[i - 1])
+        pitch_deriv_smooth = median_filter(pitch_deriv, size=5)
+
+        # --- Build note segments ---
+        # A segment boundary occurs at:
+        #   1. voiced→unvoiced or unvoiced→voiced transition
+        #   2. voiced→voiced with pitch derivative exceeding threshold
+        segments = []  # list of (start_idx, end_idx_exclusive)
+        seg_start = None
+
+        for i in range(n_frames):
+            is_voiced = voiced[i]
+            if is_voiced:
+                if seg_start is None:
+                    seg_start = i
+                else:
+                    # Check if pitch derivative forces a split
+                    if pitch_deriv_smooth[i] >= pitch_derivative_threshold:
+                        segments.append((seg_start, i))
+                        seg_start = i
+            else:
+                if seg_start is not None:
+                    segments.append((seg_start, i))
+                    seg_start = None
+
+        if seg_start is not None:
+            segments.append((seg_start, n_frames))
+
+        # --- MIDI construction ---
+        BEND_RANGE_SEMITONES = 2.0
 
         midi = PrettyMIDI()
         instrument = Instrument(program=0, name="vocals")
 
-        hop_sec = hop_length / sr
-        in_note = False
-        note_start = 0.0
-        note_pitches = []
+        # Set pitch bend range via RPN at time 0:
+        # CC 101=0, CC 100=0, CC 6=<range>, CC 38=0
+        for cc_num, cc_val in [(101, 0), (100, 0), (6, int(BEND_RANGE_SEMITONES)), (38, 0)]:
+            instrument.control_changes.append(ControlChange(cc_num, cc_val, time=0.0))
 
-        for i in range(len(pitch)):
-            t = i * hop_sec
-            conf = periodicity[i]
-            freq = pitch[i]
+        for seg_start_idx, seg_end_idx in segments:
+            seg_frames = list(range(seg_start_idx, seg_end_idx))
+            if not seg_frames:
+                continue
 
-            if conf >= confidence_threshold and freq > 0:
-                midi_pitch = 12 * np.log2(freq / 440.0) + 69
-                if not in_note:
-                    in_note = True
-                    note_start = t
-                    note_pitches = [midi_pitch]
-                else:
-                    note_pitches.append(midi_pitch)
-            else:
-                if in_note:
-                    duration_ms = (t - note_start) * 1000
-                    if duration_ms >= min_note_duration_ms and note_pitches:
-                        avg_pitch = int(round(np.median(note_pitches)))
-                        avg_pitch = max(0, min(127, avg_pitch))
-                        instrument.notes.append(
-                            Note(
-                                velocity=80,
-                                pitch=avg_pitch,
-                                start=note_start,
-                                end=t,
-                            )
-                        )
-                    in_note = False
-                    note_pitches = []
+            t_start = seg_start_idx * hop_sec
+            t_end = seg_end_idx * hop_sec
+            duration_ms = (t_end - t_start) * 1000.0
 
-        if in_note and note_pitches:
-            t_end = len(pitch) * hop_sec
-            duration_ms = (t_end - note_start) * 1000
-            if duration_ms >= min_note_duration_ms:
-                avg_pitch = int(round(np.median(note_pitches)))
-                avg_pitch = max(0, min(127, avg_pitch))
-                instrument.notes.append(
-                    Note(velocity=80, pitch=avg_pitch, start=note_start, end=t_end)
-                )
+            if duration_ms < min_note_duration_ms:
+                continue
+
+            pitches_in_seg = midi_pitch_raw[seg_start_idx:seg_end_idx]
+            valid_pitches = pitches_in_seg[~np.isnan(pitches_in_seg)]
+            if len(valid_pitches) == 0:
+                continue
+
+            base_pitch = int(np.clip(round(np.median(valid_pitches)), 0, 127))
+            velocity = rms_to_velocity(rms[seg_start_idx:seg_end_idx])
+
+            instrument.notes.append(
+                Note(velocity=velocity, pitch=base_pitch, start=t_start, end=t_end)
+            )
+
+            # Per-frame pitch bend messages
+            for frame_idx in seg_frames:
+                if np.isnan(midi_pitch_raw[frame_idx]):
+                    continue
+                deviation = midi_pitch_raw[frame_idx] - base_pitch
+                # MIDI pitch bend: 0 = full down, 8192 = center, 16383 = full up
+                bend_normalized = deviation / BEND_RANGE_SEMITONES
+                bend_value = int(np.clip(round(bend_normalized * 8191), -8192, 8191)) + 8192
+                t_frame = frame_idx * hop_sec
+                instrument.pitch_bends.append(PitchBend(bend_value, time=t_frame))
 
         midi.instruments.append(instrument)
         midi.write(output_path)


### PR DESCRIPTION
## Summary

- **transcribe_vocals.py**: major rewrite of note extraction — RMS-derived velocity (sqrt-scaled against 95th-percentile RMS, 1–127 range), pitch-derivative segmentation (median-filtered |df0/dt| > 0.9 semitones/hop forces note splits to catch re-articulations and rapid interval jumps), and per-frame MIDI pitch bend messages (±2 semitone bend range, set via RPN CC sequence at time 0). torchcrepe predict call unchanged.
- **transcribe_pitched.py**: single-line change — `multiple_pitch_bends=True` added to basic-pitch `predict()` call, enabling per-note pitch bend extraction on bass and other stems.
- **index.ts**: vocals MIDI provenance updated from `"torchcrepe"` to `"torchcrepe+expressive"`.

## Test plan

- [ ] Run bootstrap on a vocal-heavy track and verify the output MIDI file is larger (~60–70 KB vs. prior 3–10 KB) due to pitch bend messages
- [ ] Open MIDI in a DAW and confirm pitch bend lane shows continuous pitch curves within notes
- [ ] Verify velocity values vary across notes (not all 80) and correlate with loud/soft passages
- [ ] Confirm note boundaries split at re-articulations on the same pitch
- [ ] Run bootstrap on a bass-heavy track and verify bass MIDI contains pitch bend data
- [ ] Check provenance in generated map JSON shows `"tool": "torchcrepe+expressive"` for `midi-vocals`
- [ ] `bun run typecheck` and `bun run lint` pass (both confirmed clean pre-PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)