### PR TITLE
feat(pipeline): apply LRCLIB intro offset correction

### DIFF
--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -165,6 +165,7 @@ export async function bootstrap(source: string, options: BootstrapOptions = {}):
 
 					let words: WordEvent[] | undefined;
 					let lrclibValidated = true;
+					let lrclibOffsetMs: number | null = null;
 					if (stems?.vocals) {
 						log.stage("word-align");
 						try {
@@ -176,6 +177,7 @@ export async function bootstrap(source: string, options: BootstrapOptions = {}):
 							if (result) {
 								words = result.words;
 								lrclibValidated = result.lrclibValidated;
+								lrclibOffsetMs = result.lrclibOffsetMs;
 								const parts = [`${words.length} words`, result.source.replace("_", " ")];
 								if (!result.lrclibValidated && cleanedLyrics?.length) {
 									parts.push(
@@ -193,7 +195,26 @@ export async function bootstrap(source: string, options: BootstrapOptions = {}):
 						log.stageSkip("word-align", "no vocal stem");
 					}
 
-					return { lyrics: cleanedLyrics, words, lrclibValidated };
+					// Apply LRCLIB intro offset correction when validation failed and offset exceeds 2s
+					let correctedLyrics = cleanedLyrics;
+					if (
+						!lrclibValidated &&
+						lrclibOffsetMs != null &&
+						Math.abs(lrclibOffsetMs) > 2000 &&
+						cleanedLyrics?.length
+					) {
+						const offsetToApply = lrclibOffsetMs;
+						correctedLyrics = cleanedLyrics.map((line) => ({
+							...line,
+							t: Math.max(0, line.t - offsetToApply),
+							...(line.end != null ? { end: Math.max(0, line.end - offsetToApply) } : {}),
+						}));
+						log.detail(
+							`lrclib-offset: shifted ${cleanedLyrics.length} lyrics by ${(-offsetToApply / 1000).toFixed(1)}s`,
+						);
+					}
+
+					return { lyrics: correctedLyrics, words, lrclibValidated };
 				})(),
 
 				// Analysis (unchanged)


### PR DESCRIPTION
## Summary

- Extracts `lrclibOffsetMs` from the `alignWords` result into a variable scoped outside the `try` block
- After word alignment, applies the offset to all `cleanedLyrics` timestamps when `lrclibValidated` is false and `|offset| > 2000ms`
- Shifts each line's `t` and `end` (if present) by subtracting `lrclibOffsetMs`, clamped to `Math.max(0, ...)`
- Logs the correction via `log.detail`

The offset sign convention: `lrclibOffsetMs = lyric_t - cluster_t` (positive = LRCLIB is ahead of actual vocal onsets). Subtracting brings LRCLIB timestamps toward the WhisperX-detected vocal onsets. The 2s threshold avoids correcting for minor drift.

## Test plan

- [ ] `bun test` passes (64 tests, 0 failures)
- [ ] `bun run typecheck` passes (no errors)
- [ ] `bun run lint` on `src/bootstrap/index.ts` passes (pre-existing editor/ lint errors unaffected)
- [ ] Run bootstrap on a song with known LRCLIB intro offset mismatch and verify `lrclib-offset: shifted N lyrics by Xs` appears in log output and lyrics timestamps align with audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)