### PR TITLE
feat(pipeline): reconcile word text against LRCLIB canonical lyrics via Claude Haiku

### DIFF
--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -22,6 +22,7 @@ import {
 	lookupLyrics,
 	searchLyrics,
 } from "./stages/lyrics";
+import { reconcileWords } from "./stages/reconcile-words";
 import { type StemPaths, separateAudio, separateVocals } from "./stages/separate";
 import { type TranscriptionResult, transcribeStem } from "./stages/transcribe";
 import { alignWords } from "./stages/word-align";
@@ -257,7 +258,24 @@ export async function bootstrap(source: string, options: BootstrapOptions = {}):
 					);
 				}
 
-				return { lyrics: correctedLyrics, words, lrclibValidated };
+				// Word reconciliation: correct WhisperX text against LRCLIB canonical lyrics
+				let wordsReconciled = false;
+				if (words?.length && correctedLyrics?.length) {
+					try {
+						const reconciled = await reconcileWords(words, correctedLyrics, { title, artist });
+						if (reconciled.correctionCount > 0) {
+							words = reconciled.words;
+							wordsReconciled = true;
+							log.stageOk("reconcile-words", `${reconciled.correctionCount} corrections applied`);
+						} else {
+							log.stageOk("reconcile-words", "no corrections needed");
+						}
+					} catch (err) {
+						log.stageFail("reconcile-words", err instanceof Error ? err.message : String(err));
+					}
+				}
+
+				return { lyrics: correctedLyrics, words, lrclibValidated, wordsReconciled };
 			})(),
 
 			// Analysis (unchanged)
@@ -627,6 +645,13 @@ export async function bootstrap(source: string, options: BootstrapOptions = {}):
 			map.words = lyricsResult.words;
 			const wordTool = lyricsResult.lrclibValidated ? "whisperx+lrclib" : "whisperx";
 			provenance.words = { tool: wordTool, date: today };
+			if (lyricsResult.wordsReconciled) {
+				provenance["words-reconciled"] = {
+					tool: "claude-haiku",
+					version: "claude-haiku-4-5",
+					date: today,
+				};
+			}
 		}
 
 		if (finalChords?.length) {

--- a/src/bootstrap/stages/reconcile-words.ts
+++ b/src/bootstrap/stages/reconcile-words.ts
@@ -1,0 +1,126 @@
+import type { LyricLine, WordEvent } from "../../../schema/map";
+
+export interface ReconcileResult {
+	words: WordEvent[];
+	correctionCount: number;
+}
+
+const SYSTEM_PROMPT = `You reconcile word-level audio transcription with canonical lyrics for a song. You receive two representations:
+
+1. LRCLIB lines: canonical text with line-start timestamps
+2. WhisperX words: transcribed text with per-word timestamps
+
+Return JSON only: {"corrections": [{"i": <index>, "text": "<corrected>"}]}
+
+Rules:
+- Only include words that need text correction
+- Never add or remove words — only correct existing slots
+- Preserve original word boundaries (don't merge or split)
+- If a WhisperX word is an ad-lib or vocal flourish absent from LRCLIB, leave it unchanged
+- Prefer LRCLIB spelling/punctuation when the word clearly matches
+- If uncertain, leave unchanged`;
+
+function formatLrclibLines(lyrics: LyricLine[]): string {
+	return lyrics
+		.map((line) => {
+			const totalMs = line.t;
+			const minutes = Math.floor(totalMs / 60000);
+			const seconds = Math.floor((totalMs % 60000) / 1000);
+			const centiseconds = Math.floor((totalMs % 1000) / 10);
+			return `[${minutes}:${String(seconds).padStart(2, "0")}.${String(centiseconds).padStart(2, "0")}] ${line.text}`;
+		})
+		.join("\n");
+}
+
+function formatWhisperXWords(words: WordEvent[]): string {
+	return words.map((w, i) => `${i}: "${w.text}" (${w.t}ms)`).join("\n");
+}
+
+interface Correction {
+	i: number;
+	text: string;
+}
+
+function parseCorrections(raw: string): Correction[] | undefined {
+	// Try to extract JSON from the response (may be wrapped in markdown fences)
+	let jsonStr = raw.trim();
+	const fenceMatch = jsonStr.match(/```(?:json)?\s*([\s\S]*?)```/);
+	if (fenceMatch) {
+		jsonStr = fenceMatch[1].trim();
+	}
+
+	try {
+		const parsed = JSON.parse(jsonStr) as { corrections?: Correction[] };
+		if (!Array.isArray(parsed.corrections)) return undefined;
+		return parsed.corrections;
+	} catch {
+		return undefined;
+	}
+}
+
+export async function reconcileWords(
+	words: WordEvent[],
+	lyrics: LyricLine[],
+	metadata: { title?: string; artist?: string },
+): Promise<ReconcileResult> {
+	// Fallback: empty lyrics means nothing to reconcile against
+	if (lyrics.length === 0) {
+		return { words, correctionCount: 0 };
+	}
+
+	// Check if claude CLI is available
+	if (!Bun.which("claude")) {
+		return { words, correctionCount: 0 };
+	}
+
+	const userPrompt = `Song: ${metadata.title || "Unknown"} by ${metadata.artist || "Unknown"}
+
+LRCLIB lines:
+${formatLrclibLines(lyrics)}
+
+WhisperX words (${words.length} total):
+${formatWhisperXWords(words)}`;
+
+	let stdout: string;
+	try {
+		const proc = Bun.spawn(
+			["claude", "--bare", "-p", userPrompt, "--model", "haiku", "--system-prompt", SYSTEM_PROMPT],
+			{
+				stdout: "pipe",
+				stderr: "pipe",
+			},
+		);
+
+		const exitCode = await proc.exited;
+		if (exitCode !== 0) {
+			return { words, correctionCount: 0 };
+		}
+
+		stdout = await new Response(proc.stdout).text();
+	} catch {
+		return { words, correctionCount: 0 };
+	}
+
+	const corrections = parseCorrections(stdout);
+	if (!corrections) {
+		return { words, correctionCount: 0 };
+	}
+
+	// Apply valid corrections
+	const correctedWords = [...words];
+	let correctionCount = 0;
+
+	for (const c of corrections) {
+		// Discard out-of-bounds
+		if (c.i < 0 || c.i >= correctedWords.length) continue;
+		// Discard empty text
+		if (!c.text || c.text.trim().length === 0) continue;
+		// Discard no-ops
+		if (c.text === correctedWords[c.i].text) continue;
+
+		correctedWords[c.i] = { ...correctedWords[c.i], text: c.text };
+		correctionCount++;
+	}
+
+	return { words: correctedWords, correctionCount };
+}


### PR DESCRIPTION
## Summary
- Add `reconcile-words` stage that shells out to `claude` CLI (Haiku model) to correct WhisperX transcription text against LRCLIB canonical lyrics
- Integrated into the lyrics chain IIFE after LRCLIB offset correction, before return
- Provenance tracked as `words-reconciled` in the analysis record when corrections are applied

## Design
WhisperX transcribes what it hears — slurred, melismatic, or ad-libbed words often differ from the canonical LRCLIB text. The reconciliation stage sends both representations to Claude Haiku, which returns index-targeted corrections. Only text is corrected; timestamps are preserved, and no words are added or removed.

Robust fallback chain ensures the pipeline never breaks:
1. Empty lyrics → skip
2. `claude` CLI not on PATH → skip
3. Non-zero exit → skip
4. Unparseable response → skip
5. Out-of-bounds or empty corrections → discard individually

## Test plan
- [x] `bun test` — 64 tests pass
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (on changed files)
- [ ] Run `bun run bootstrap` on a song with LRCLIB lyrics to verify corrections appear in pipeline output

🤖 Generated with [Claude Code](https://claude.com/claude-code)