### PR TITLE
feat(deploy): GitHub Pages deployment for maps with manifest

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,62 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'maps/**'
+      - 'editor/**'
+
+  workflow_dispatch:
+
+permissions:
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build site directory
+        run: |
+          mkdir -p _site/maps/midi
+          cp maps/*.json _site/maps/ 2>/dev/null || true
+          cp maps/midi/*.mid _site/maps/midi/ 2>/dev/null || true
+          touch _site/.nojekyll
+
+          # Generate manifest of all maps
+          node -e "
+            const fs = require('fs');
+            const maps = fs.readdirSync('maps')
+              .filter(f => f.endsWith('.json'))
+              .map(f => {
+                const data = JSON.parse(fs.readFileSync('maps/' + f));
+                return {
+                  id: data.id,
+                  title: data.metadata?.title,
+                  artist: data.metadata?.artist,
+                  duration_ms: data.duration_ms,
+                  file: f,
+                };
+              });
+            fs.writeFileSync('_site/maps/manifest.json', JSON.stringify(maps, null, 2));
+            console.log('Generated manifest with ' + maps.length + ' maps');
+          "
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy-pages.yml` using the modern `actions/deploy-pages` approach (not legacy branch-based)
- Copies `maps/*.json` and `maps/midi/*.mid` into `_site/` on push to main
- Generates `_site/maps/manifest.json` with `id`, `title`, `artist`, `duration_ms`, and `file` for each map
- Adds `.nojekyll` to prevent GitHub Pages from running Jekyll over the files
- Triggers on `maps/**` or `editor/**` changes, plus `workflow_dispatch` for manual deploys
- Editor build step is a placeholder — can be wired in once the editor has a build pipeline

## Test plan

- [ ] Merge and confirm the Actions run completes without error
- [ ] Verify `https://hartphoenix.github.io/pulsemap/maps/manifest.json` returns valid JSON
- [ ] Spot-check one map JSON at `https://hartphoenix.github.io/pulsemap/maps/<filename>.json`
- [ ] Spot-check one MIDI file at `https://hartphoenix.github.io/pulsemap/maps/midi/<hash>.mid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)