### PR TITLE
feat(editor): timeline rendering with lanes, zoom, scroll, playhead

### DIFF
--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -1,3 +1,4 @@
+import { Timeline } from "./components/Timeline";
 import { TransportBar } from "./components/TransportBar";
 import { useMap } from "./hooks/useMap";
 import { usePlayback } from "./hooks/usePlayback";
@@ -80,6 +81,13 @@ export function App() {
 				onPause={pause}
 				onSeek={seek}
 				onRateChange={setRate}
+			/>
+
+			<Timeline
+				map={map}
+				position={position}
+				playing={playing}
+				onSeek={seek}
 			/>
 
 			<div style={styles.debugInfo}>

--- a/editor/src/components/Lane.tsx
+++ b/editor/src/components/Lane.tsx
@@ -1,0 +1,49 @@
+import type { CSSProperties, ReactNode } from "react";
+import { COLORS } from "../constants";
+
+interface LaneProps {
+  label: string;
+  height: number;
+  children: ReactNode;
+}
+
+export function Lane({ label, height, children }: LaneProps) {
+  return (
+    <div style={{ ...styles.lane, height }}>
+      <div style={styles.label}>{label}</div>
+      <div style={{ ...styles.content, height }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+const styles: Record<string, CSSProperties> = {
+  lane: {
+    display: "flex",
+    flexDirection: "row",
+    position: "relative",
+    borderBottom: "1px solid #1a1a2e",
+  },
+  label: {
+    width: 72,
+    minWidth: 72,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "flex-end",
+    paddingRight: 8,
+    fontSize: 11,
+    fontWeight: 600,
+    color: "#888",
+    textTransform: "uppercase",
+    letterSpacing: "0.05em",
+    background: COLORS.background,
+    zIndex: 2,
+  },
+  content: {
+    position: "relative",
+    flex: 1,
+    overflow: "hidden",
+    background: COLORS.laneBg,
+  },
+};

--- a/editor/src/components/LaneToggles.tsx
+++ b/editor/src/components/LaneToggles.tsx
@@ -1,0 +1,70 @@
+import type { CSSProperties } from "react";
+import { LANE_ORDER, COLORS, type LaneName } from "../constants";
+import type { PulseMap } from "pulsemap/schema";
+
+interface LaneTogglesProps {
+  map: PulseMap;
+  visibility: Record<LaneName, boolean>;
+  onToggle: (lane: LaneName) => void;
+}
+
+const LANE_COLORS: Record<LaneName, string> = {
+  sections: COLORS.sections,
+  lyrics: COLORS.lyrics,
+  words: COLORS.words,
+  chords: COLORS.chords,
+  beats: COLORS.beats,
+};
+
+function hasData(map: PulseMap, lane: LaneName): boolean {
+  switch (lane) {
+    case "sections":
+      return !!map.sections && map.sections.length > 0;
+    case "lyrics":
+      return !!map.lyrics && map.lyrics.length > 0;
+    case "words":
+      return !!map.words && map.words.length > 0;
+    case "chords":
+      return !!map.chords && map.chords.length > 0;
+    case "beats":
+      return !!map.beats && map.beats.length > 0;
+  }
+}
+
+export function LaneToggles({ map, visibility, onToggle }: LaneTogglesProps) {
+  return (
+    <div style={styles.container}>
+      {LANE_ORDER.map((lane) => {
+        if (!hasData(map, lane)) return null;
+        return (
+          <label key={lane} style={styles.label}>
+            <input
+              type="checkbox"
+              checked={visibility[lane]}
+              onChange={() => onToggle(lane)}
+              style={{ accentColor: LANE_COLORS[lane] }}
+            />
+            <span style={{ color: LANE_COLORS[lane] }}>{lane}</span>
+          </label>
+        );
+      })}
+    </div>
+  );
+}
+
+const styles: Record<string, CSSProperties> = {
+  container: {
+    display: "flex",
+    gap: 12,
+    alignItems: "center",
+    flexWrap: "wrap",
+  },
+  label: {
+    display: "flex",
+    gap: 4,
+    alignItems: "center",
+    fontSize: 13,
+    cursor: "pointer",
+    textTransform: "capitalize",
+  },
+};

--- a/editor/src/components/Playhead.tsx
+++ b/editor/src/components/Playhead.tsx
@@ -1,0 +1,33 @@
+import type { CSSProperties } from "react";
+import { COLORS } from "../constants";
+
+interface PlayheadProps {
+  positionX: number;
+}
+
+export function Playhead({ positionX }: PlayheadProps) {
+  if (positionX < 0) return null;
+
+  return (
+    <div
+      style={{
+        ...styles.line,
+        transform: `translateX(${positionX}px)`,
+      }}
+    />
+  );
+}
+
+const styles: Record<string, CSSProperties> = {
+  line: {
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    left: 72, // offset by lane label width
+    width: 2,
+    background: COLORS.playhead,
+    zIndex: 10,
+    pointerEvents: "none",
+    willChange: "transform",
+  },
+};

--- a/editor/src/components/Timeline.tsx
+++ b/editor/src/components/Timeline.tsx
@@ -1,0 +1,271 @@
+import { useState, useCallback, useRef, useEffect, type CSSProperties } from "react";
+import type { PulseMap } from "pulsemap/schema";
+import { useTimeline } from "../hooks/useTimeline";
+import { COLORS, LANE_ORDER, type LaneName } from "../constants";
+import { Playhead } from "./Playhead";
+import { LaneToggles } from "./LaneToggles";
+import { BeatLane } from "./lanes/BeatLane";
+import { ChordLane } from "./lanes/ChordLane";
+import { LyricLane } from "./lanes/LyricLane";
+import { WordLane } from "./lanes/WordLane";
+import { SectionLane } from "./lanes/SectionLane";
+
+interface TimelineProps {
+  map: PulseMap;
+  position: number;
+  playing: boolean;
+  onSeek: (ms: number) => void;
+}
+
+function hasLaneData(map: PulseMap, lane: LaneName): boolean {
+  switch (lane) {
+    case "sections":
+      return !!map.sections && map.sections.length > 0;
+    case "lyrics":
+      return !!map.lyrics && map.lyrics.length > 0;
+    case "words":
+      return !!map.words && map.words.length > 0;
+    case "chords":
+      return !!map.chords && map.chords.length > 0;
+    case "beats":
+      return !!map.beats && map.beats.length > 0;
+  }
+}
+
+export function Timeline({ map, position, playing, onSeek }: TimelineProps) {
+  const [visibility, setVisibility] = useState<Record<LaneName, boolean>>({
+    sections: true,
+    lyrics: true,
+    words: true,
+    chords: true,
+    beats: true,
+  });
+
+  const [viewportWidth, setViewportWidth] = useState(800);
+  const measureRef = useRef<HTMLDivElement | null>(null);
+
+  const {
+    scrollMs,
+    pxPerMs,
+    following,
+    msToX,
+    containerRef,
+    enableFollow,
+    disableFollow,
+    zoomIn,
+    zoomOut,
+  } = useTimeline({
+    durationMs: map.duration_ms,
+    position,
+    playing,
+  });
+
+  // Measure viewport width
+  useEffect(() => {
+    const el = measureRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setViewportWidth(entry.contentRect.width);
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  // Merge container refs
+  const setRefs = useCallback(
+    (node: HTMLDivElement | null) => {
+      (containerRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
+      (measureRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
+    },
+    [containerRef],
+  );
+
+  const toggleLane = useCallback((lane: LaneName) => {
+    setVisibility((prev) => ({ ...prev, [lane]: !prev[lane] }));
+  }, []);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      // Only seek if clicking on the timeline content area (not lane labels)
+      const rect = e.currentTarget.getBoundingClientRect();
+      const x = e.clientX - rect.left + e.currentTarget.scrollLeft - 72; // subtract label width
+      if (x < 0) return;
+      const ms = x / pxPerMs + scrollMs;
+      if (ms >= 0 && ms <= map.duration_ms) {
+        onSeek(ms);
+        disableFollow();
+      }
+    },
+    [pxPerMs, scrollMs, map.duration_ms, onSeek, disableFollow],
+  );
+
+  const totalWidthPx = map.duration_ms * pxPerMs;
+  const playheadX = msToX(position);
+
+  // Content area viewport width (total minus label column)
+  const contentViewportWidth = Math.max(viewportWidth - 72, 100);
+
+  return (
+    <div style={styles.wrapper}>
+      <div style={styles.toolbar}>
+        <LaneToggles
+          map={map}
+          visibility={visibility}
+          onToggle={toggleLane}
+        />
+        <div style={styles.toolbarRight}>
+          <button type="button" onClick={zoomOut} style={styles.zoomButton}>
+            -
+          </button>
+          <span style={styles.zoomLabel}>
+            {(pxPerMs * 1000).toFixed(0)} px/s
+          </span>
+          <button type="button" onClick={zoomIn} style={styles.zoomButton}>
+            +
+          </button>
+          {!following && playing && (
+            <button
+              type="button"
+              onClick={enableFollow}
+              style={styles.followButton}
+            >
+              Follow
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div
+        ref={setRefs}
+        style={styles.scrollContainer}
+        onClick={handleClick}
+      >
+        <div style={{ ...styles.innerTrack, width: totalWidthPx + 72 }}>
+          <Playhead positionX={playheadX} />
+
+          {LANE_ORDER.map((lane) => {
+            if (!hasLaneData(map, lane) || !visibility[lane]) return null;
+            switch (lane) {
+              case "sections":
+                return (
+                  <SectionLane
+                    key={lane}
+                    sections={map.sections!}
+                    scrollMs={scrollMs}
+                    pxPerMs={pxPerMs}
+                    viewportWidthPx={contentViewportWidth}
+                  />
+                );
+              case "lyrics":
+                return (
+                  <LyricLane
+                    key={lane}
+                    lyrics={map.lyrics!}
+                    scrollMs={scrollMs}
+                    pxPerMs={pxPerMs}
+                    viewportWidthPx={contentViewportWidth}
+                  />
+                );
+              case "words":
+                return (
+                  <WordLane
+                    key={lane}
+                    words={map.words!}
+                    scrollMs={scrollMs}
+                    pxPerMs={pxPerMs}
+                    viewportWidthPx={contentViewportWidth}
+                  />
+                );
+              case "chords":
+                return (
+                  <ChordLane
+                    key={lane}
+                    chords={map.chords!}
+                    scrollMs={scrollMs}
+                    pxPerMs={pxPerMs}
+                    viewportWidthPx={contentViewportWidth}
+                  />
+                );
+              case "beats":
+                return (
+                  <BeatLane
+                    key={lane}
+                    beats={map.beats!}
+                    scrollMs={scrollMs}
+                    pxPerMs={pxPerMs}
+                    viewportWidthPx={contentViewportWidth}
+                  />
+                );
+            }
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const styles: Record<string, CSSProperties> = {
+  wrapper: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 8,
+    marginTop: 16,
+  },
+  toolbar: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  toolbarRight: {
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+  },
+  zoomButton: {
+    width: 28,
+    height: 28,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    background: "#2a2a4a",
+    border: "1px solid #444",
+    borderRadius: 4,
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: 700,
+    cursor: "pointer",
+  },
+  zoomLabel: {
+    fontSize: 12,
+    color: "#888",
+    fontFamily: "monospace",
+    minWidth: 60,
+    textAlign: "center",
+  },
+  followButton: {
+    padding: "4px 10px",
+    background: "#2a2a4a",
+    border: `1px solid ${COLORS.playhead}`,
+    borderRadius: 4,
+    color: COLORS.playhead,
+    fontSize: 12,
+    cursor: "pointer",
+    marginLeft: 4,
+  },
+  scrollContainer: {
+    overflowX: "auto",
+    overflowY: "hidden",
+    background: COLORS.background,
+    borderRadius: 4,
+    border: "1px solid #2a2a4a",
+    cursor: "crosshair",
+  },
+  innerTrack: {
+    position: "relative",
+    minHeight: 40,
+  },
+};

--- a/editor/src/components/lanes/BeatLane.tsx
+++ b/editor/src/components/lanes/BeatLane.tsx
@@ -1,0 +1,52 @@
+import { useMemo } from "react";
+import type { BeatEvent } from "pulsemap/schema";
+import { COLORS, LANE_HEIGHTS } from "../../constants";
+import { Lane } from "../Lane";
+import { findVisibleRange } from "./visibility";
+
+interface BeatLaneProps {
+  beats: BeatEvent[];
+  scrollMs: number;
+  pxPerMs: number;
+  viewportWidthPx: number;
+}
+
+export function BeatLane({
+  beats,
+  scrollMs,
+  pxPerMs,
+  viewportWidthPx,
+}: BeatLaneProps) {
+  const viewportEndMs = scrollMs + viewportWidthPx / pxPerMs;
+  const height = LANE_HEIGHTS.beats;
+
+  const visibleBeats = useMemo(() => {
+    const [start, end] = findVisibleRange(beats, scrollMs, viewportEndMs);
+    return beats.slice(start, end);
+  }, [beats, scrollMs, viewportEndMs]);
+
+  return (
+    <Lane label="Beats" height={height}>
+      {visibleBeats.map((beat, i) => {
+        const x = (beat.t - scrollMs) * pxPerMs;
+        const lineHeight = beat.downbeat ? height : height * 0.7;
+        const opacity = beat.downbeat ? 1 : 0.5;
+        const width = beat.downbeat ? 2 : 1;
+        return (
+          <div
+            key={`${beat.t}-${i}`}
+            style={{
+              position: "absolute",
+              left: x,
+              bottom: 0,
+              width,
+              height: lineHeight,
+              background: COLORS.beats,
+              opacity,
+            }}
+          />
+        );
+      })}
+    </Lane>
+  );
+}

--- a/editor/src/components/lanes/ChordLane.tsx
+++ b/editor/src/components/lanes/ChordLane.tsx
@@ -1,0 +1,73 @@
+import { useMemo } from "react";
+import type { ChordEvent } from "pulsemap/schema";
+import { COLORS, LANE_HEIGHTS } from "../../constants";
+import { Lane } from "../Lane";
+import { findVisibleRange } from "./visibility";
+
+interface ChordLaneProps {
+  chords: ChordEvent[];
+  scrollMs: number;
+  pxPerMs: number;
+  viewportWidthPx: number;
+}
+
+export function ChordLane({
+  chords,
+  scrollMs,
+  pxPerMs,
+  viewportWidthPx,
+}: ChordLaneProps) {
+  const viewportEndMs = scrollMs + viewportWidthPx / pxPerMs;
+  const height = LANE_HEIGHTS.chords;
+
+  const visibleChords = useMemo(() => {
+    const [start, end] = findVisibleRange(chords, scrollMs, viewportEndMs);
+    return chords.slice(start, end).map((chord, i) => {
+      const idx = start + i;
+      const endMs =
+        chord.end ?? (idx + 1 < chords.length ? chords[idx + 1].t : undefined);
+      return { ...chord, endMs };
+    });
+  }, [chords, scrollMs, viewportEndMs]);
+
+  return (
+    <Lane label="Chords" height={height}>
+      {visibleChords.map((chord, i) => {
+        const x = (chord.t - scrollMs) * pxPerMs;
+        const w = chord.endMs
+          ? (chord.endMs - chord.t) * pxPerMs
+          : 60; // fallback width
+        return (
+          <div
+            key={`${chord.t}-${i}`}
+            style={{
+              position: "absolute",
+              left: x,
+              top: 2,
+              width: Math.max(w, 20),
+              height: height - 4,
+              background: COLORS.chords,
+              borderRadius: 3,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              overflow: "hidden",
+            }}
+          >
+            <span
+              style={{
+                fontSize: 11,
+                fontWeight: 700,
+                color: "#1a1a2e",
+                whiteSpace: "nowrap",
+                padding: "0 4px",
+              }}
+            >
+              {chord.chord}
+            </span>
+          </div>
+        );
+      })}
+    </Lane>
+  );
+}

--- a/editor/src/components/lanes/LyricLane.tsx
+++ b/editor/src/components/lanes/LyricLane.tsx
@@ -1,0 +1,75 @@
+import { useMemo } from "react";
+import type { LyricLine } from "pulsemap/schema";
+import { COLORS, LANE_HEIGHTS } from "../../constants";
+import { Lane } from "../Lane";
+import { findVisibleRange } from "./visibility";
+
+interface LyricLaneProps {
+  lyrics: LyricLine[];
+  scrollMs: number;
+  pxPerMs: number;
+  viewportWidthPx: number;
+}
+
+export function LyricLane({
+  lyrics,
+  scrollMs,
+  pxPerMs,
+  viewportWidthPx,
+}: LyricLaneProps) {
+  const viewportEndMs = scrollMs + viewportWidthPx / pxPerMs;
+  const height = LANE_HEIGHTS.lyrics;
+
+  const visibleLyrics = useMemo(() => {
+    const [start, end] = findVisibleRange(lyrics, scrollMs, viewportEndMs);
+    return lyrics.slice(start, end).map((line, i) => {
+      const idx = start + i;
+      const endMs =
+        line.end ??
+        (idx + 1 < lyrics.length ? lyrics[idx + 1].t : undefined);
+      return { ...line, endMs };
+    });
+  }, [lyrics, scrollMs, viewportEndMs]);
+
+  return (
+    <Lane label="Lyrics" height={height}>
+      {visibleLyrics.map((line, i) => {
+        const x = (line.t - scrollMs) * pxPerMs;
+        const w = line.endMs
+          ? (line.endMs - line.t) * pxPerMs
+          : 120;
+        return (
+          <div
+            key={`${line.t}-${i}`}
+            style={{
+              position: "absolute",
+              left: x,
+              top: 2,
+              width: Math.max(w, 30),
+              height: height - 4,
+              background: `${COLORS.lyrics}33`,
+              border: `1px solid ${COLORS.lyrics}66`,
+              borderRadius: 3,
+              display: "flex",
+              alignItems: "center",
+              overflow: "hidden",
+              padding: "0 4px",
+            }}
+          >
+            <span
+              style={{
+                fontSize: 11,
+                color: COLORS.lyrics,
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
+              {line.text}
+            </span>
+          </div>
+        );
+      })}
+    </Lane>
+  );
+}

--- a/editor/src/components/lanes/SectionLane.tsx
+++ b/editor/src/components/lanes/SectionLane.tsx
@@ -1,0 +1,82 @@
+import { useMemo } from "react";
+import type { Section } from "pulsemap/schema";
+import { COLORS, LANE_HEIGHTS } from "../../constants";
+import { Lane } from "../Lane";
+import { findVisibleRange } from "./visibility";
+
+interface SectionLaneProps {
+  sections: Section[];
+  scrollMs: number;
+  pxPerMs: number;
+  viewportWidthPx: number;
+}
+
+/** Rotate through a small palette so adjacent sections differ */
+const SECTION_PALETTE = [
+  "#6c5ce7",
+  "#00b894",
+  "#e17055",
+  "#0984e3",
+  "#fdcb6e",
+  "#e84393",
+  "#00cec9",
+  "#d63031",
+];
+
+export function SectionLane({
+  sections,
+  scrollMs,
+  pxPerMs,
+  viewportWidthPx,
+}: SectionLaneProps) {
+  const viewportEndMs = scrollMs + viewportWidthPx / pxPerMs;
+  const height = LANE_HEIGHTS.sections;
+
+  const visibleSections = useMemo(() => {
+    const [start, end] = findVisibleRange(sections, scrollMs, viewportEndMs);
+    return sections.slice(start, end).map((s, i) => ({
+      ...s,
+      colorIdx: (start + i) % SECTION_PALETTE.length,
+    }));
+  }, [sections, scrollMs, viewportEndMs]);
+
+  return (
+    <Lane label="Sections" height={height}>
+      {visibleSections.map((section, i) => {
+        const x = (section.t - scrollMs) * pxPerMs;
+        const w = (section.end - section.t) * pxPerMs;
+        const color = SECTION_PALETTE[section.colorIdx];
+        return (
+          <div
+            key={`${section.t}-${i}`}
+            style={{
+              position: "absolute",
+              left: x,
+              top: 0,
+              width: Math.max(w, 20),
+              height,
+              background: `${color}33`,
+              borderLeft: `2px solid ${color}`,
+              display: "flex",
+              alignItems: "center",
+              padding: "0 6px",
+              overflow: "hidden",
+            }}
+          >
+            <span
+              style={{
+                fontSize: 11,
+                fontWeight: 600,
+                color: COLORS.sections,
+                whiteSpace: "nowrap",
+                textTransform: "capitalize",
+              }}
+            >
+              {section.label ?? section.type}
+            </span>
+          </div>
+        );
+      })}
+    </Lane>
+  );
+}

--- a/editor/src/components/lanes/WordLane.tsx
+++ b/editor/src/components/lanes/WordLane.tsx
@@ -1,0 +1,75 @@
+import { useMemo } from "react";
+import type { WordEvent } from "pulsemap/schema";
+import { COLORS, LANE_HEIGHTS } from "../../constants";
+import { Lane } from "../Lane";
+import { findVisibleRange } from "./visibility";
+
+interface WordLaneProps {
+  words: WordEvent[];
+  scrollMs: number;
+  pxPerMs: number;
+  viewportWidthPx: number;
+}
+
+export function WordLane({
+  words,
+  scrollMs,
+  pxPerMs,
+  viewportWidthPx,
+}: WordLaneProps) {
+  const viewportEndMs = scrollMs + viewportWidthPx / pxPerMs;
+  const height = LANE_HEIGHTS.words;
+
+  const visibleWords = useMemo(() => {
+    const [start, end] = findVisibleRange(words, scrollMs, viewportEndMs);
+    return words.slice(start, end).map((word, i) => {
+      const idx = start + i;
+      const endMs =
+        word.end ??
+        (idx + 1 < words.length ? words[idx + 1].t : undefined);
+      return { ...word, endMs };
+    });
+  }, [words, scrollMs, viewportEndMs]);
+
+  return (
+    <Lane label="Words" height={height}>
+      {visibleWords.map((word, i) => {
+        const x = (word.t - scrollMs) * pxPerMs;
+        const w = word.endMs
+          ? (word.endMs - word.t) * pxPerMs
+          : 40;
+        return (
+          <div
+            key={`${word.t}-${i}`}
+            style={{
+              position: "absolute",
+              left: x,
+              top: 2,
+              width: Math.max(w, 16),
+              height: height - 4,
+              background: `${COLORS.words}33`,
+              border: `1px solid ${COLORS.words}55`,
+              borderRadius: 2,
+              display: "flex",
+              alignItems: "center",
+              overflow: "hidden",
+              padding: "0 2px",
+            }}
+          >
+            <span
+              style={{
+                fontSize: 10,
+                color: COLORS.words,
+                whiteSpace: "nowrap",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+              }}
+            >
+              {word.text}
+            </span>
+          </div>
+        );
+      })}
+    </Lane>
+  );
+}

--- a/editor/src/components/lanes/visibility.ts
+++ b/editor/src/components/lanes/visibility.ts
@@ -1,0 +1,46 @@
+/**
+ * Binary search to find the range of events visible in the current viewport.
+ * Events must be sorted by `t` in ascending order.
+ *
+ * Returns [startIdx, endIdx) — a half-open range suitable for Array.slice().
+ * Includes one event before the viewport (for blocks that start before but
+ * extend into view) and one after (for safety margin).
+ */
+export function findVisibleRange(
+  events: ReadonlyArray<{ t: number; end?: number }>,
+  viewportStartMs: number,
+  viewportEndMs: number,
+): [number, number] {
+  if (events.length === 0) return [0, 0];
+
+  // Find first event that could be visible:
+  // Binary search for the first event where t >= viewportStartMs
+  let lo = 0;
+  let hi = events.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (events[mid].t < viewportStartMs) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  // Back up one to catch blocks that start before viewport but extend into it
+  const startIdx = Math.max(0, lo - 1);
+
+  // Find first event past the viewport end
+  lo = startIdx;
+  hi = events.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (events[mid].t <= viewportEndMs) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  // Include one extra for safety
+  const endIdx = Math.min(events.length, lo + 1);
+
+  return [startIdx, endIdx];
+}

--- a/editor/src/constants.ts
+++ b/editor/src/constants.ts
@@ -1,0 +1,44 @@
+/** Timeline color scheme */
+export const COLORS = {
+  background: "#1a1a2e",
+  laneBg: "#0d1b2a",
+  beats: "#64ffda",
+  chords: "#ffd93d",
+  lyrics: "#c4b5fd",
+  words: "#a78bfa",
+  sections: "#6c5ce7",
+  playhead: "#ff4757",
+} as const;
+
+/** Lane heights in pixels */
+export const LANE_HEIGHTS = {
+  sections: 40,
+  lyrics: 36,
+  words: 28,
+  chords: 36,
+  beats: 24,
+} as const;
+
+/** Default zoom: pixels per millisecond */
+export const DEFAULT_PX_PER_MS = 0.15;
+
+/** Minimum and maximum zoom bounds */
+export const MIN_PX_PER_MS = 0.01;
+export const MAX_PX_PER_MS = 2.0;
+
+/** Playhead position as fraction of viewport width when following */
+export const FOLLOW_OFFSET_FRACTION = 0.25;
+
+/** Zoom speed multiplier for wheel events */
+export const ZOOM_FACTOR = 1.1;
+
+/** Lane names in display order (top to bottom) */
+export const LANE_ORDER = [
+  "sections",
+  "lyrics",
+  "words",
+  "chords",
+  "beats",
+] as const;
+
+export type LaneName = (typeof LANE_ORDER)[number];

--- a/editor/src/hooks/useTimeline.ts
+++ b/editor/src/hooks/useTimeline.ts
@@ -1,0 +1,166 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+import {
+  DEFAULT_PX_PER_MS,
+  MIN_PX_PER_MS,
+  MAX_PX_PER_MS,
+  FOLLOW_OFFSET_FRACTION,
+  ZOOM_FACTOR,
+} from "../constants";
+
+interface UseTimelineOptions {
+  durationMs: number;
+  position: number;
+  playing: boolean;
+}
+
+interface UseTimelineResult {
+  scrollMs: number;
+  pxPerMs: number;
+  following: boolean;
+  msToX: (ms: number) => number;
+  xToMs: (x: number) => number;
+  zoomIn: () => void;
+  zoomOut: () => void;
+  setZoom: (pxPerMs: number) => void;
+  setScrollMs: (ms: number) => void;
+  enableFollow: () => void;
+  disableFollow: () => void;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+}
+
+export function useTimeline({
+  durationMs,
+  position,
+  playing,
+}: UseTimelineOptions): UseTimelineResult {
+  const [pxPerMs, setPxPerMs] = useState(DEFAULT_PX_PER_MS);
+  const [scrollMs, setScrollMs] = useState(0);
+  const [following, setFollowing] = useState(true);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const userScrolledRef = useRef(false);
+
+  const clampZoom = useCallback(
+    (v: number) => Math.max(MIN_PX_PER_MS, Math.min(MAX_PX_PER_MS, v)),
+    [],
+  );
+
+  const msToX = useCallback(
+    (ms: number) => (ms - scrollMs) * pxPerMs,
+    [scrollMs, pxPerMs],
+  );
+
+  const xToMs = useCallback(
+    (x: number) => x / pxPerMs + scrollMs,
+    [scrollMs, pxPerMs],
+  );
+
+  const zoomIn = useCallback(() => {
+    setPxPerMs((prev) => clampZoom(prev * ZOOM_FACTOR));
+  }, [clampZoom]);
+
+  const zoomOut = useCallback(() => {
+    setPxPerMs((prev) => clampZoom(prev / ZOOM_FACTOR));
+  }, [clampZoom]);
+
+  const setZoom = useCallback(
+    (v: number) => setPxPerMs(clampZoom(v)),
+    [clampZoom],
+  );
+
+  const enableFollow = useCallback(() => setFollowing(true), []);
+  const disableFollow = useCallback(() => {
+    setFollowing(false);
+    userScrolledRef.current = true;
+  }, []);
+
+  // Follow mode: keep playhead at 25% of viewport
+  useEffect(() => {
+    if (!following || !playing) return;
+    const el = containerRef.current;
+    if (!el) return;
+    const viewportWidthMs = el.clientWidth / pxPerMs;
+    const targetScroll = position - viewportWidthMs * FOLLOW_OFFSET_FRACTION;
+    setScrollMs(Math.max(0, Math.min(targetScroll, durationMs)));
+  }, [following, playing, position, pxPerMs, durationMs]);
+
+  // Sync container scroll position from scrollMs
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const scrollLeft = scrollMs * pxPerMs;
+    if (Math.abs(el.scrollLeft - scrollLeft) > 1) {
+      el.scrollLeft = scrollLeft;
+    }
+  }, [scrollMs, pxPerMs]);
+
+  // Listen for user scroll and wheel events on the container
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    function handleScroll() {
+      if (!el) return;
+      const newScrollMs = el.scrollLeft / pxPerMs;
+      // If user initiated the scroll (not programmatic follow), break follow
+      if (userScrolledRef.current) {
+        setScrollMs(newScrollMs);
+      }
+      userScrolledRef.current = false;
+    }
+
+    function handleWheel(e: WheelEvent) {
+      e.preventDefault();
+      if (e.ctrlKey || e.metaKey) {
+        // Horizontal scroll
+        if (!el) return;
+        const deltaMs = e.deltaY / pxPerMs;
+        setScrollMs((prev) =>
+          Math.max(0, Math.min(prev + deltaMs, durationMs)),
+        );
+        setFollowing(false);
+      } else if (e.shiftKey) {
+        // Zoom (shift+wheel)
+        const zoomDir = e.deltaY > 0 ? -1 : 1;
+        const factor = zoomDir > 0 ? ZOOM_FACTOR : 1 / ZOOM_FACTOR;
+        setPxPerMs((prev) => clampZoom(prev * factor));
+      } else {
+        // Default: horizontal scroll
+        if (!el) return;
+        const deltaMs = e.deltaY / pxPerMs;
+        setScrollMs((prev) =>
+          Math.max(0, Math.min(prev + deltaMs, durationMs)),
+        );
+        setFollowing(false);
+      }
+    }
+
+    function handleManualScroll() {
+      userScrolledRef.current = true;
+    }
+
+    el.addEventListener("wheel", handleWheel, { passive: false });
+    el.addEventListener("scroll", handleScroll);
+    el.addEventListener("mousedown", handleManualScroll);
+
+    return () => {
+      el.removeEventListener("wheel", handleWheel);
+      el.removeEventListener("scroll", handleScroll);
+      el.removeEventListener("mousedown", handleManualScroll);
+    };
+  }, [pxPerMs, durationMs, clampZoom]);
+
+  return {
+    scrollMs,
+    pxPerMs,
+    following,
+    msToX,
+    xToMs,
+    zoomIn,
+    zoomOut,
+    setZoom,
+    setScrollMs,
+    enableFollow,
+    disableFollow,
+    containerRef,
+  };
+}


### PR DESCRIPTION
Rebased version of #25 (conflict-resolved with A8 lint fixes).

## Summary
- Timeline viewport model with follow mode, zoom, scroll
- 5 lane renderers: sections, lyrics, words, chords, beats
- Binary search virtualization for visible events
- Playhead with rAF positioning
- Lane toggles for visibility control
- Click-to-seek on timeline