### PR TITLE
feat(editor): editing interactions with undo/redo, drag, snap, edit panel

### DIFF
--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -1,14 +1,129 @@
+import { useCallback } from "react";
 import { Timeline } from "./components/Timeline";
 import { TransportBar } from "./components/TransportBar";
 import { useMap } from "./hooks/useMap";
 import { usePlayback } from "./hooks/usePlayback";
 import { parseEditorParams } from "./types";
+import { EditorProvider, useEditor } from "./state/context";
+import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
+import { useBeatSnap } from "./hooks/useBeatSnap";
+import type { PulseMap } from "pulsemap/schema";
 
 function getMapId(): string | null {
 	const path = window.location.pathname;
 	// Strip leading slash, return null if empty
 	const id = path.replace(/^\/+/, "");
 	return id || null;
+}
+
+/** Inner editor component that has access to EditorProvider context */
+function EditorContent({
+	map,
+	playing,
+	position,
+	containerId,
+	playbackAvailable,
+	onPlay,
+	onPause,
+	onSeek,
+	onRateChange,
+}: {
+	map: PulseMap;
+	playing: boolean;
+	position: number;
+	containerId: string;
+	playbackAvailable: boolean;
+	onPlay: () => void;
+	onPause: () => void;
+	onSeek: (ms: number) => void;
+	onRateChange: (rate: number) => void;
+}) {
+	const { state } = useEditor();
+	const workingMap = state.working;
+
+	const { snapToNearestBeat } = useBeatSnap({
+		beats: workingMap.beats,
+		enabled: true,
+		subdivision: "beat",
+	});
+
+	const handlePlayPause = useCallback(() => {
+		if (playing) {
+			onPause();
+		} else {
+			onPlay();
+		}
+	}, [playing, onPlay, onPause]);
+
+	const handleSave = useCallback(() => {
+		if (!state.dirty) return;
+		try {
+			localStorage.setItem(
+				`pulsemap-edit-${workingMap.id}`,
+				JSON.stringify(workingMap),
+			);
+		} catch {
+			// localStorage might be full or unavailable
+		}
+	}, [state.dirty, workingMap]);
+
+	useKeyboardShortcuts({
+		onPlayPause: handlePlayPause,
+		onSave: handleSave,
+		snapEnabled: true,
+		snapFn: snapToNearestBeat,
+	});
+
+	const meta = workingMap.metadata;
+	const params = parseEditorParams(window.location.search);
+
+	return (
+		<>
+			<header style={styles.header}>
+				<h1 style={styles.title}>{meta?.title ?? workingMap.id}</h1>
+				{meta?.artist && <span style={styles.artist}>{meta.artist}</span>}
+				<div style={styles.metaRow}>
+					{meta?.album && <span style={styles.metaTag}>{meta.album}</span>}
+					{meta?.key && <span style={styles.metaTag}>{meta.key}</span>}
+					{meta?.tempo && <span style={styles.metaTag}>{Math.round(meta.tempo)} BPM</span>}
+					{meta?.time_signature && <span style={styles.metaTag}>{meta.time_signature}</span>}
+					{state.dirty && <span style={styles.dirtyTag}>Edited</span>}
+				</div>
+			</header>
+
+			<TransportBar
+				playing={playing}
+				position={position}
+				duration={workingMap.duration_ms}
+				playbackAvailable={playbackAvailable}
+				containerId={containerId}
+				onPlay={onPlay}
+				onPause={onPause}
+				onSeek={onSeek}
+				onRateChange={onRateChange}
+			/>
+
+			<Timeline
+				map={workingMap}
+				position={position}
+				playing={playing}
+				onSeek={onSeek}
+			/>
+
+			<div style={styles.debugInfo}>
+				<code>
+					{workingMap.id} | {Math.round(workingMap.duration_ms / 1000)}s
+					{workingMap.lyrics ? ` | ${workingMap.lyrics.length} lyric lines` : ""}
+					{workingMap.words ? ` | ${workingMap.words.length} words` : ""}
+					{workingMap.chords ? ` | ${workingMap.chords.length} chords` : ""}
+					{workingMap.beats ? ` | ${workingMap.beats.length} beats` : ""}
+					{state.history.length > 0 ? ` | ${state.history.length} edits` : ""}
+					{params.lane ? ` | lane=${params.lane}` : ""}
+					{params.index != null ? ` | index=${params.index}` : ""}
+				</code>
+			</div>
+		</>
+	);
 }
 
 export function App() {
@@ -56,58 +171,28 @@ export function App() {
 
 	if (!map) return null;
 
-	const meta = map.metadata;
-
 	return (
 		<div style={styles.container}>
-			<header style={styles.header}>
-				<h1 style={styles.title}>{meta?.title ?? map.id}</h1>
-				{meta?.artist && <span style={styles.artist}>{meta.artist}</span>}
-				<div style={styles.metaRow}>
-					{meta?.album && <span style={styles.metaTag}>{meta.album}</span>}
-					{meta?.key && <span style={styles.metaTag}>{meta.key}</span>}
-					{meta?.tempo && <span style={styles.metaTag}>{Math.round(meta.tempo)} BPM</span>}
-					{meta?.time_signature && <span style={styles.metaTag}>{meta.time_signature}</span>}
-				</div>
-			</header>
-
-			<TransportBar
-				playing={playing}
-				position={position}
-				duration={map.duration_ms}
-				playbackAvailable={playbackAvailable}
-				containerId={containerId}
-				onPlay={play}
-				onPause={pause}
-				onSeek={seek}
-				onRateChange={setRate}
-			/>
-
-			<Timeline
-				map={map}
-				position={position}
-				playing={playing}
-				onSeek={seek}
-			/>
-
-			<div style={styles.debugInfo}>
-				<code>
-					{map.id} | {Math.round(map.duration_ms / 1000)}s
-					{map.lyrics ? ` | ${map.lyrics.length} lyric lines` : ""}
-					{map.words ? ` | ${map.words.length} words` : ""}
-					{map.chords ? ` | ${map.chords.length} chords` : ""}
-					{map.beats ? ` | ${map.beats.length} beats` : ""}
-					{params.lane ? ` | lane=${params.lane}` : ""}
-					{params.index != null ? ` | index=${params.index}` : ""}
-				</code>
-			</div>
+			<EditorProvider map={map}>
+				<EditorContent
+					map={map}
+					playing={playing}
+					position={position}
+					containerId={containerId}
+					playbackAvailable={playbackAvailable}
+					onPlay={play}
+					onPause={pause}
+					onSeek={seek}
+					onRateChange={setRate}
+				/>
+			</EditorProvider>
 		</div>
 	);
 }
 
 const styles: Record<string, React.CSSProperties> = {
 	container: {
-		maxWidth: "900px",
+		maxWidth: 1200,
 		margin: "0 auto",
 		padding: "24px",
 		fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
@@ -161,6 +246,13 @@ const styles: Record<string, React.CSSProperties> = {
 		borderRadius: "3px",
 		fontSize: "13px",
 		color: "#bbb",
+	},
+	dirtyTag: {
+		padding: "2px 8px",
+		background: "#3a3a00",
+		borderRadius: "3px",
+		fontSize: "13px",
+		color: "#ffcc00",
 	},
 	debugInfo: {
 		marginTop: "20px",

--- a/editor/src/components/EditPanel.tsx
+++ b/editor/src/components/EditPanel.tsx
@@ -1,0 +1,512 @@
+import { useCallback, type CSSProperties } from "react";
+import { SECTION_TYPES } from "pulsemap/schema";
+import type {
+  ChordEvent,
+  Section,
+  WordEvent,
+  LyricLine,
+} from "pulsemap/schema";
+import { useEditor } from "../state/context";
+import {
+  editTextAction,
+  editFieldAction,
+  moveAction,
+  resizeAction,
+  deleteAction,
+  insertAction,
+} from "../state/actions";
+import { COLORS } from "../constants";
+import type { EditableLane } from "../state/types";
+
+function formatMs(ms: number): string {
+  const s = ms / 1000;
+  return s.toFixed(3);
+}
+
+function parseMs(value: string): number | null {
+  const n = Number.parseFloat(value) * 1000;
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Get a single event from the working map */
+function getEvent(map: Record<string, unknown>, lane: EditableLane, index: number): unknown | null {
+  const arr = map[lane] as unknown[] | undefined;
+  if (!arr || index >= arr.length) return null;
+  return arr[index];
+}
+
+export function EditPanel() {
+  const { state, dispatch } = useEditor();
+  const { selection, working } = state;
+
+  if (!selection) {
+    return (
+      <div style={styles.panel}>
+        <div style={styles.empty}>Select an event to edit</div>
+      </div>
+    );
+  }
+
+  const { lane, index } = selection;
+  const event = getEvent(working as unknown as Record<string, unknown>, lane, index);
+  if (!event) {
+    return (
+      <div style={styles.panel}>
+        <div style={styles.empty}>Event not found</div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={styles.panel}>
+      <div style={styles.header}>
+        <span style={{ color: COLORS[lane], fontWeight: 600, textTransform: "capitalize" }}>
+          {lane}
+        </span>
+        <span style={styles.indexBadge}>#{index}</span>
+      </div>
+
+      {lane === "chords" && (
+        <ChordFields
+          event={event as ChordEvent}
+          lane={lane}
+          index={index}
+          dispatch={dispatch}
+        />
+      )}
+      {lane === "sections" && (
+        <SectionFields
+          event={event as Section}
+          lane={lane}
+          index={index}
+          dispatch={dispatch}
+          working={working}
+        />
+      )}
+      {lane === "words" && (
+        <WordFields
+          event={event as WordEvent}
+          lane={lane}
+          index={index}
+          dispatch={dispatch}
+        />
+      )}
+      {lane === "lyrics" && (
+        <LyricFields
+          event={event as LyricLine}
+          lane={lane}
+          index={index}
+          dispatch={dispatch}
+        />
+      )}
+
+      <div style={styles.actions}>
+        <button
+          type="button"
+          style={styles.deleteButton}
+          onClick={() => dispatch(deleteAction(lane, index, event))}
+        >
+          Delete
+        </button>
+      </div>
+
+      <div style={styles.shortcuts}>
+        <div style={styles.shortcutRow}>
+          <kbd style={styles.kbd}>Del</kbd> Delete
+        </div>
+        <div style={styles.shortcutRow}>
+          <kbd style={styles.kbd}>Esc</kbd> Deselect
+        </div>
+        <div style={styles.shortcutRow}>
+          <kbd style={styles.kbd}>Cmd+Z</kbd> Undo
+        </div>
+        <div style={styles.shortcutRow}>
+          <kbd style={styles.kbd}>Cmd+Shift+Z</kbd> Redo
+        </div>
+        <div style={styles.shortcutRow}>
+          <kbd style={styles.kbd}>Left/Right</kbd> Nudge
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// -- Field editors for each lane type --
+
+interface FieldProps<T> {
+  event: T;
+  lane: EditableLane;
+  index: number;
+  dispatch: (action: ReturnType<typeof editTextAction>) => void;
+}
+
+function TimeField({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  onChange: (ms: number) => void;
+}) {
+  return (
+    <label style={styles.field}>
+      <span style={styles.fieldLabel}>{label}</span>
+      <input
+        type="text"
+        style={styles.input}
+        value={formatMs(value)}
+        onChange={(e) => {
+          const ms = parseMs(e.target.value);
+          if (ms !== null) onChange(ms);
+        }}
+      />
+      <span style={styles.fieldUnit}>s</span>
+    </label>
+  );
+}
+
+function TextField({
+  label,
+  value,
+  onChange,
+  multiline = false,
+}: {
+  label: string;
+  value: string;
+  onChange: (text: string) => void;
+  multiline?: boolean;
+}) {
+  if (multiline) {
+    return (
+      <label style={styles.field}>
+        <span style={styles.fieldLabel}>{label}</span>
+        <textarea
+          style={{ ...styles.input, minHeight: 60, resize: "vertical" }}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      </label>
+    );
+  }
+  return (
+    <label style={styles.field}>
+      <span style={styles.fieldLabel}>{label}</span>
+      <input
+        type="text"
+        style={styles.input}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </label>
+  );
+}
+
+function ChordFields({ event, lane, index, dispatch }: FieldProps<ChordEvent>) {
+  return (
+    <div style={styles.fields}>
+      <TimeField
+        label="Start"
+        value={event.t}
+        onChange={(ms) => dispatch(moveAction(lane, index, event.t, ms))}
+      />
+      <TextField
+        label="Chord"
+        value={event.chord}
+        onChange={(text) =>
+          dispatch(editTextAction(lane, index, "chord", event.chord, text))
+        }
+      />
+      {event.end != null && (
+        <TimeField
+          label="End"
+          value={event.end}
+          onChange={(ms) => dispatch(resizeAction(lane, index, event.end, ms))}
+        />
+      )}
+    </div>
+  );
+}
+
+function SectionFields({
+  event,
+  lane,
+  index,
+  dispatch,
+  working,
+}: FieldProps<Section> & { working: Record<string, unknown> }) {
+  const sections = (working as unknown as { sections?: Section[] }).sections;
+
+  const handleSplit = useCallback(
+    (atMs: number) => {
+      if (atMs <= event.t || atMs >= event.end) return;
+      // Resize current section to end at split point
+      dispatch(resizeAction(lane, index, event.end, atMs));
+      // Insert new section after split point
+      const newSection: Section = {
+        t: atMs,
+        end: event.end,
+        type: event.type,
+        label: event.label,
+      };
+      dispatch(insertAction(lane, index + 1, newSection));
+    },
+    [event, lane, index, dispatch],
+  );
+
+  // Check for adjacent sections for merge
+  const canMergeNext =
+    sections &&
+    index + 1 < sections.length &&
+    Math.abs(sections[index + 1].t - event.end) < 10;
+
+  const handleMerge = useCallback(() => {
+    if (!sections || index + 1 >= sections.length) return;
+    const next = sections[index + 1];
+    // Extend current section's end to next section's end
+    dispatch(resizeAction(lane, index, event.end, next.end));
+    // Delete the next section
+    dispatch(deleteAction(lane, index + 1, next));
+  }, [sections, event, lane, index, dispatch]);
+
+  return (
+    <div style={styles.fields}>
+      <TimeField
+        label="Start"
+        value={event.t}
+        onChange={(ms) => dispatch(moveAction(lane, index, event.t, ms))}
+      />
+      <label style={styles.field}>
+        <span style={styles.fieldLabel}>Type</span>
+        <select
+          style={styles.input}
+          value={SECTION_TYPES.includes(event.type as typeof SECTION_TYPES[number]) ? event.type : "__custom"}
+          onChange={(e) => {
+            const val = e.target.value;
+            if (val !== "__custom") {
+              dispatch(editTextAction(lane, index, "type", event.type, val));
+            }
+          }}
+        >
+          {SECTION_TYPES.map((st) => (
+            <option key={st} value={st}>
+              {st}
+            </option>
+          ))}
+          {!SECTION_TYPES.includes(event.type as typeof SECTION_TYPES[number]) && (
+            <option value="__custom">{event.type}</option>
+          )}
+        </select>
+      </label>
+      <TextField
+        label="Label"
+        value={event.label ?? ""}
+        onChange={(text) =>
+          dispatch(
+            editTextAction(lane, index, "label", event.label ?? "", text || ""),
+          )
+        }
+      />
+      <TimeField
+        label="End"
+        value={event.end}
+        onChange={(ms) => dispatch(resizeAction(lane, index, event.end, ms))}
+      />
+      <div style={styles.sectionActions}>
+        <button
+          type="button"
+          style={styles.actionButton}
+          onClick={() => {
+            const mid = event.t + (event.end - event.t) / 2;
+            handleSplit(mid);
+          }}
+        >
+          Split at midpoint
+        </button>
+        {canMergeNext && (
+          <button
+            type="button"
+            style={styles.actionButton}
+            onClick={handleMerge}
+          >
+            Merge with next
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function WordFields({ event, lane, index, dispatch }: FieldProps<WordEvent>) {
+  return (
+    <div style={styles.fields}>
+      <TimeField
+        label="Start"
+        value={event.t}
+        onChange={(ms) => dispatch(moveAction(lane, index, event.t, ms))}
+      />
+      <TextField
+        label="Text"
+        value={event.text}
+        onChange={(text) =>
+          dispatch(editTextAction(lane, index, "text", event.text, text))
+        }
+      />
+      {event.end != null && (
+        <TimeField
+          label="End"
+          value={event.end}
+          onChange={(ms) => dispatch(resizeAction(lane, index, event.end, ms))}
+        />
+      )}
+    </div>
+  );
+}
+
+function LyricFields({ event, lane, index, dispatch }: FieldProps<LyricLine>) {
+  return (
+    <div style={styles.fields}>
+      <TimeField
+        label="Start"
+        value={event.t}
+        onChange={(ms) => dispatch(moveAction(lane, index, event.t, ms))}
+      />
+      <TextField
+        label="Text"
+        value={event.text}
+        onChange={(text) =>
+          dispatch(editTextAction(lane, index, "text", event.text, text))
+        }
+        multiline
+      />
+      {event.end != null && (
+        <TimeField
+          label="End"
+          value={event.end}
+          onChange={(ms) => dispatch(resizeAction(lane, index, event.end, ms))}
+        />
+      )}
+    </div>
+  );
+}
+
+const styles: Record<string, CSSProperties> = {
+  panel: {
+    width: 280,
+    minWidth: 280,
+    background: "#12121e",
+    borderLeft: "1px solid #2a2a4a",
+    padding: 16,
+    display: "flex",
+    flexDirection: "column",
+    gap: 16,
+    overflowY: "auto",
+    fontSize: 13,
+    color: "#e0e0e0",
+  },
+  empty: {
+    color: "#666",
+    fontSize: 13,
+    textAlign: "center",
+    marginTop: 40,
+  },
+  header: {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+    paddingBottom: 8,
+    borderBottom: "1px solid #2a2a4a",
+  },
+  indexBadge: {
+    fontSize: 11,
+    color: "#888",
+    fontFamily: "monospace",
+  },
+  fields: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 10,
+  },
+  field: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 3,
+  },
+  fieldLabel: {
+    fontSize: 11,
+    color: "#888",
+    textTransform: "uppercase",
+    letterSpacing: "0.05em",
+  },
+  fieldUnit: {
+    fontSize: 11,
+    color: "#666",
+    marginTop: 2,
+  },
+  input: {
+    background: "#1a1a2e",
+    border: "1px solid #333",
+    borderRadius: 3,
+    padding: "5px 8px",
+    color: "#e0e0e0",
+    fontSize: 13,
+    fontFamily: "monospace",
+    outline: "none",
+    width: "100%",
+    boxSizing: "border-box" as const,
+  },
+  actions: {
+    marginTop: 8,
+  },
+  deleteButton: {
+    width: "100%",
+    padding: "6px 12px",
+    background: "#3a1a1a",
+    border: "1px solid #662222",
+    borderRadius: 4,
+    color: "#ff6666",
+    fontSize: 13,
+    cursor: "pointer",
+  },
+  sectionActions: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 6,
+    marginTop: 4,
+  },
+  actionButton: {
+    padding: "5px 10px",
+    background: "#2a2a4a",
+    border: "1px solid #444",
+    borderRadius: 3,
+    color: "#ccc",
+    fontSize: 12,
+    cursor: "pointer",
+    textAlign: "center" as const,
+  },
+  shortcuts: {
+    marginTop: "auto",
+    paddingTop: 12,
+    borderTop: "1px solid #2a2a4a",
+    display: "flex",
+    flexDirection: "column",
+    gap: 4,
+  },
+  shortcutRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: 6,
+    fontSize: 11,
+    color: "#666",
+  },
+  kbd: {
+    display: "inline-block",
+    padding: "1px 5px",
+    background: "#1a1a2e",
+    border: "1px solid #333",
+    borderRadius: 3,
+    fontSize: 10,
+    fontFamily: "monospace",
+    color: "#aaa",
+  },
+};

--- a/editor/src/components/EventBlock.tsx
+++ b/editor/src/components/EventBlock.tsx
@@ -1,0 +1,211 @@
+import { useCallback, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import { useDrag, type DragMode } from "../hooks/useDrag";
+
+interface EventBlockProps {
+  /** Left position in px (already offset from scrollMs) */
+  x: number;
+  /** Width in px */
+  width: number;
+  /** Height in px */
+  height: number;
+  /** Whether this event is selected */
+  selected: boolean;
+  /** Color for the selection highlight */
+  color: string;
+  /** Start time in ms (for drag calculations) */
+  startMs: number;
+  /** End time in ms (for resize calculations) */
+  endMs?: number;
+  /** Pixels per ms for coordinate conversion */
+  pxPerMs: number;
+  /** Snap function */
+  snapFn: (ms: number) => number;
+  /** Whether snap is enabled */
+  snapEnabled: boolean;
+  /** Content to render inside the block */
+  children: ReactNode;
+  /** Called when the block is clicked (select) */
+  onClick?: () => void;
+  /** Called when dragging completes a move */
+  onMove?: (newT: number) => void;
+  /** Called when resizing the start edge completes */
+  onResizeStart?: (newT: number) => void;
+  /** Called when resizing the end edge completes */
+  onResizeEnd?: (newEnd: number) => void;
+  /** Called on double-click */
+  onDoubleClick?: () => void;
+  /** Top offset within the lane */
+  top?: number;
+}
+
+const RESIZE_HANDLE_WIDTH = 6;
+
+export function EventBlock({
+  x,
+  width,
+  height,
+  selected,
+  color,
+  startMs,
+  endMs,
+  pxPerMs,
+  snapFn,
+  snapEnabled,
+  children,
+  onClick,
+  onMove,
+  onResizeStart,
+  onResizeEnd,
+  onDoubleClick,
+  top = 2,
+}: EventBlockProps) {
+  const [dragOffset, setDragOffset] = useState<{ dx: number; mode: DragMode } | null>(null);
+  const blockRef = useRef<HTMLDivElement>(null);
+
+  const handleDragMove = useCallback(
+    (deltaMs: number, currentMs: number, mode: DragMode) => {
+      if (mode === "move") {
+        setDragOffset({ dx: deltaMs * pxPerMs, mode });
+      } else if (mode === "resize-start") {
+        setDragOffset({ dx: deltaMs * pxPerMs, mode });
+      } else if (mode === "resize-end") {
+        setDragOffset({ dx: deltaMs * pxPerMs, mode });
+      }
+    },
+    [pxPerMs],
+  );
+
+  const handleDragEnd = useCallback(
+    (_deltaMs: number, currentMs: number, mode: DragMode) => {
+      setDragOffset(null);
+      if (mode === "move") {
+        onMove?.(currentMs);
+      } else if (mode === "resize-start") {
+        onResizeStart?.(currentMs);
+      } else if (mode === "resize-end") {
+        onResizeEnd?.(currentMs);
+      }
+    },
+    [onMove, onResizeStart, onResizeEnd],
+  );
+
+  const { startDrag } = useDrag({
+    pxPerMs,
+    snapFn,
+    snapEnabled,
+    onDragMove: handleDragMove,
+    onDragEnd: handleDragEnd,
+  });
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      // Determine drag mode based on where the click lands
+      const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+      const relX = e.clientX - rect.left;
+      const blockWidth = rect.width;
+
+      if (relX <= RESIZE_HANDLE_WIDTH && onResizeStart) {
+        startDrag(e, "resize-start", startMs);
+      } else if (relX >= blockWidth - RESIZE_HANDLE_WIDTH && onResizeEnd && endMs != null) {
+        startDrag(e, "resize-end", endMs);
+      } else {
+        startDrag(e, "move", startMs);
+      }
+    },
+    [startDrag, startMs, endMs, onResizeStart, onResizeEnd],
+  );
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onClick?.();
+    },
+    [onClick],
+  );
+
+  const handleDblClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onDoubleClick?.();
+    },
+    [onDoubleClick],
+  );
+
+  // Compute visual position during drag
+  let visualX = x;
+  let visualWidth = width;
+  if (dragOffset) {
+    if (dragOffset.mode === "move") {
+      visualX = x + dragOffset.dx;
+    } else if (dragOffset.mode === "resize-start") {
+      visualX = x + dragOffset.dx;
+      visualWidth = width - dragOffset.dx;
+    } else if (dragOffset.mode === "resize-end") {
+      visualWidth = width + dragOffset.dx;
+    }
+  }
+
+  const borderColor = selected ? "#fff" : `${color}66`;
+
+  const style: CSSProperties = {
+    position: "absolute",
+    left: visualX,
+    top,
+    width: Math.max(visualWidth, 8),
+    height: height - top * 2,
+    background: selected ? `${color}55` : `${color}33`,
+    border: `1px solid ${borderColor}`,
+    borderRadius: 3,
+    display: "flex",
+    alignItems: "center",
+    overflow: "hidden",
+    cursor: dragOffset ? "grabbing" : "grab",
+    userSelect: "none",
+    zIndex: selected ? 5 : 1,
+    boxSizing: "border-box",
+    transition: dragOffset ? "none" : "background 0.1s, border-color 0.1s",
+  };
+
+  return (
+    <div
+      ref={blockRef}
+      style={style}
+      onClick={handleClick}
+      onDoubleClick={handleDblClick}
+      onPointerDown={handlePointerDown}
+    >
+      {/* Left resize handle */}
+      {onResizeStart && (
+        <div
+          style={{
+            position: "absolute",
+            left: 0,
+            top: 0,
+            width: RESIZE_HANDLE_WIDTH,
+            height: "100%",
+            cursor: "ew-resize",
+          }}
+        />
+      )}
+
+      {/* Content */}
+      <div style={{ flex: 1, overflow: "hidden", padding: "0 4px" }}>
+        {children}
+      </div>
+
+      {/* Right resize handle */}
+      {onResizeEnd && endMs != null && (
+        <div
+          style={{
+            position: "absolute",
+            right: 0,
+            top: 0,
+            width: RESIZE_HANDLE_WIDTH,
+            height: "100%",
+            cursor: "ew-resize",
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/editor/src/components/SnapIndicator.tsx
+++ b/editor/src/components/SnapIndicator.tsx
@@ -1,0 +1,44 @@
+import type { CSSProperties } from "react";
+import { COLORS } from "../constants";
+
+interface SnapIndicatorProps {
+  /** Snap point positions in px (already converted from ms) */
+  snapPointsPx: number[];
+  /** Height of the timeline content area */
+  height: number;
+}
+
+/**
+ * Renders vertical guide lines at beat snap positions
+ * during drag operations.
+ */
+export function SnapIndicator({ snapPointsPx, height }: SnapIndicatorProps) {
+  if (snapPointsPx.length === 0) return null;
+
+  return (
+    <>
+      {snapPointsPx.map((px) => (
+        <div
+          key={px}
+          style={{
+            ...styles.line,
+            left: px,
+            height,
+          }}
+        />
+      ))}
+    </>
+  );
+}
+
+const styles: Record<string, CSSProperties> = {
+  line: {
+    position: "absolute",
+    top: 0,
+    width: 1,
+    background: COLORS.beats,
+    opacity: 0.3,
+    pointerEvents: "none",
+    zIndex: 4,
+  },
+};

--- a/editor/src/components/Timeline.tsx
+++ b/editor/src/components/Timeline.tsx
@@ -1,9 +1,13 @@
 import { useState, useCallback, useRef, useEffect, type CSSProperties } from "react";
 import type { PulseMap } from "pulsemap/schema";
 import { useTimeline } from "../hooks/useTimeline";
+import { useBeatSnap, type SnapSubdivision } from "../hooks/useBeatSnap";
+import { useEditor } from "../state/context";
+import { deselectAction } from "../state/actions";
 import { COLORS, LANE_ORDER, type LaneName } from "../constants";
 import { Playhead } from "./Playhead";
 import { LaneToggles } from "./LaneToggles";
+import { EditPanel } from "./EditPanel";
 import { BeatLane } from "./lanes/BeatLane";
 import { ChordLane } from "./lanes/ChordLane";
 import { LyricLane } from "./lanes/LyricLane";
@@ -33,6 +37,9 @@ function hasLaneData(map: PulseMap, lane: LaneName): boolean {
 }
 
 export function Timeline({ map, position, playing, onSeek }: TimelineProps) {
+  const { state, dispatch } = useEditor();
+  const workingMap = state.working;
+
   const [visibility, setVisibility] = useState<Record<LaneName, boolean>>({
     sections: true,
     lyrics: true,
@@ -40,6 +47,9 @@ export function Timeline({ map, position, playing, onSeek }: TimelineProps) {
     chords: true,
     beats: true,
   });
+
+  const [snapEnabled, setSnapEnabled] = useState(true);
+  const [snapSubdivision, setSnapSubdivision] = useState<SnapSubdivision>("beat");
 
   const [viewportWidth, setViewportWidth] = useState(800);
   const measureRef = useRef<HTMLDivElement | null>(null);
@@ -55,10 +65,22 @@ export function Timeline({ map, position, playing, onSeek }: TimelineProps) {
     zoomIn,
     zoomOut,
   } = useTimeline({
-    durationMs: map.duration_ms,
+    durationMs: workingMap.duration_ms,
     position,
     playing,
   });
+
+  const { snapToNearestBeat } = useBeatSnap({
+    beats: workingMap.beats,
+    enabled: snapEnabled,
+    subdivision: snapSubdivision,
+  });
+
+  // Identity snap function when snap is disabled
+  const snapFn = useCallback(
+    (ms: number) => (snapEnabled ? snapToNearestBeat(ms) : ms),
+    [snapEnabled, snapToNearestBeat],
+  );
 
   // Measure viewport width
   useEffect(() => {
@@ -93,125 +115,179 @@ export function Timeline({ map, position, playing, onSeek }: TimelineProps) {
       const x = e.clientX - rect.left + e.currentTarget.scrollLeft - 72; // subtract label width
       if (x < 0) return;
       const ms = x / pxPerMs + scrollMs;
-      if (ms >= 0 && ms <= map.duration_ms) {
+      if (ms >= 0 && ms <= workingMap.duration_ms) {
         onSeek(ms);
         disableFollow();
+        // Deselect when clicking empty timeline area
+        dispatch(deselectAction());
       }
     },
-    [pxPerMs, scrollMs, map.duration_ms, onSeek, disableFollow],
+    [pxPerMs, scrollMs, workingMap.duration_ms, onSeek, disableFollow, dispatch],
   );
 
-  const totalWidthPx = map.duration_ms * pxPerMs;
+  const totalWidthPx = workingMap.duration_ms * pxPerMs;
   const playheadX = msToX(position);
 
   // Content area viewport width (total minus label column)
   const contentViewportWidth = Math.max(viewportWidth - 72, 100);
 
   return (
-    <div style={styles.wrapper}>
-      <div style={styles.toolbar}>
-        <LaneToggles
-          map={map}
-          visibility={visibility}
-          onToggle={toggleLane}
-        />
-        <div style={styles.toolbarRight}>
-          <button type="button" onClick={zoomOut} style={styles.zoomButton}>
-            -
-          </button>
-          <span style={styles.zoomLabel}>
-            {(pxPerMs * 1000).toFixed(0)} px/s
-          </span>
-          <button type="button" onClick={zoomIn} style={styles.zoomButton}>
-            +
-          </button>
-          {!following && playing && (
+    <div style={styles.outerWrapper}>
+      <div style={styles.wrapper}>
+        <div style={styles.toolbar}>
+          <LaneToggles
+            map={workingMap}
+            visibility={visibility}
+            onToggle={toggleLane}
+          />
+          <div style={styles.toolbarRight}>
+            {/* Snap controls */}
             <button
               type="button"
-              onClick={enableFollow}
-              style={styles.followButton}
+              onClick={() => setSnapEnabled((s) => !s)}
+              style={{
+                ...styles.snapButton,
+                ...(snapEnabled ? styles.snapButtonActive : {}),
+              }}
+              title={`Beat snap: ${snapEnabled ? "ON" : "OFF"} (hold Alt to temporarily disable)`}
             >
-              Follow
+              Snap
             </button>
-          )}
+            {snapEnabled && (
+              <select
+                value={snapSubdivision}
+                onChange={(e) => setSnapSubdivision(e.target.value as SnapSubdivision)}
+                style={styles.subdivisionSelect}
+              >
+                <option value="beat">Beat</option>
+                <option value="half">1/2</option>
+                <option value="quarter">1/4</option>
+              </select>
+            )}
+
+            <div style={styles.separator} />
+
+            <button type="button" onClick={zoomOut} style={styles.zoomButton}>
+              -
+            </button>
+            <span style={styles.zoomLabel}>
+              {(pxPerMs * 1000).toFixed(0)} px/s
+            </span>
+            <button type="button" onClick={zoomIn} style={styles.zoomButton}>
+              +
+            </button>
+            {!following && playing && (
+              <button
+                type="button"
+                onClick={enableFollow}
+                style={styles.followButton}
+              >
+                Follow
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div style={styles.timelineRow}>
+          <div
+            ref={setRefs}
+            style={styles.scrollContainer}
+            onClick={handleClick}
+          >
+            <div style={{ ...styles.innerTrack, width: totalWidthPx + 72 }}>
+              <Playhead positionX={playheadX} />
+
+              {LANE_ORDER.map((lane) => {
+                if (!hasLaneData(workingMap, lane) || !visibility[lane]) return null;
+                switch (lane) {
+                  case "sections":
+                    return (
+                      <SectionLane
+                        key={lane}
+                        sections={workingMap.sections!}
+                        scrollMs={scrollMs}
+                        pxPerMs={pxPerMs}
+                        viewportWidthPx={contentViewportWidth}
+                        snapFn={snapFn}
+                        snapEnabled={snapEnabled}
+                        durationMs={workingMap.duration_ms}
+                      />
+                    );
+                  case "lyrics":
+                    return (
+                      <LyricLane
+                        key={lane}
+                        lyrics={workingMap.lyrics!}
+                        scrollMs={scrollMs}
+                        pxPerMs={pxPerMs}
+                        viewportWidthPx={contentViewportWidth}
+                        snapFn={snapFn}
+                        snapEnabled={snapEnabled}
+                      />
+                    );
+                  case "words":
+                    return (
+                      <WordLane
+                        key={lane}
+                        words={workingMap.words!}
+                        scrollMs={scrollMs}
+                        pxPerMs={pxPerMs}
+                        viewportWidthPx={contentViewportWidth}
+                        snapFn={snapFn}
+                        snapEnabled={snapEnabled}
+                      />
+                    );
+                  case "chords":
+                    return (
+                      <ChordLane
+                        key={lane}
+                        chords={workingMap.chords!}
+                        scrollMs={scrollMs}
+                        pxPerMs={pxPerMs}
+                        viewportWidthPx={contentViewportWidth}
+                        snapFn={snapFn}
+                        snapEnabled={snapEnabled}
+                      />
+                    );
+                  case "beats":
+                    return (
+                      <BeatLane
+                        key={lane}
+                        beats={workingMap.beats!}
+                        scrollMs={scrollMs}
+                        pxPerMs={pxPerMs}
+                        viewportWidthPx={contentViewportWidth}
+                      />
+                    );
+                }
+              })}
+            </div>
+          </div>
+
+          <EditPanel />
         </div>
       </div>
 
-      <div
-        ref={setRefs}
-        style={styles.scrollContainer}
-        onClick={handleClick}
-      >
-        <div style={{ ...styles.innerTrack, width: totalWidthPx + 72 }}>
-          <Playhead positionX={playheadX} />
-
-          {LANE_ORDER.map((lane) => {
-            if (!hasLaneData(map, lane) || !visibility[lane]) return null;
-            switch (lane) {
-              case "sections":
-                return (
-                  <SectionLane
-                    key={lane}
-                    sections={map.sections!}
-                    scrollMs={scrollMs}
-                    pxPerMs={pxPerMs}
-                    viewportWidthPx={contentViewportWidth}
-                  />
-                );
-              case "lyrics":
-                return (
-                  <LyricLane
-                    key={lane}
-                    lyrics={map.lyrics!}
-                    scrollMs={scrollMs}
-                    pxPerMs={pxPerMs}
-                    viewportWidthPx={contentViewportWidth}
-                  />
-                );
-              case "words":
-                return (
-                  <WordLane
-                    key={lane}
-                    words={map.words!}
-                    scrollMs={scrollMs}
-                    pxPerMs={pxPerMs}
-                    viewportWidthPx={contentViewportWidth}
-                  />
-                );
-              case "chords":
-                return (
-                  <ChordLane
-                    key={lane}
-                    chords={map.chords!}
-                    scrollMs={scrollMs}
-                    pxPerMs={pxPerMs}
-                    viewportWidthPx={contentViewportWidth}
-                  />
-                );
-              case "beats":
-                return (
-                  <BeatLane
-                    key={lane}
-                    beats={map.beats!}
-                    scrollMs={scrollMs}
-                    pxPerMs={pxPerMs}
-                    viewportWidthPx={contentViewportWidth}
-                  />
-                );
-            }
-          })}
+      {state.dirty && (
+        <div style={styles.dirtyIndicator}>
+          Unsaved changes ({state.history.length} edit{state.history.length !== 1 ? "s" : ""})
         </div>
-      </div>
+      )}
     </div>
   );
 }
 
 const styles: Record<string, CSSProperties> = {
+  outerWrapper: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 4,
+    marginTop: 16,
+  },
   wrapper: {
     display: "flex",
     flexDirection: "column",
     gap: 8,
-    marginTop: 16,
   },
   toolbar: {
     display: "flex",
@@ -224,6 +300,34 @@ const styles: Record<string, CSSProperties> = {
     display: "flex",
     alignItems: "center",
     gap: 6,
+  },
+  snapButton: {
+    padding: "4px 10px",
+    background: "#2a2a4a",
+    border: "1px solid #444",
+    borderRadius: 4,
+    color: "#888",
+    fontSize: 12,
+    cursor: "pointer",
+  },
+  snapButtonActive: {
+    background: "#1a3a4a",
+    borderColor: COLORS.beats,
+    color: COLORS.beats,
+  },
+  subdivisionSelect: {
+    padding: "3px 6px",
+    background: "#2a2a4a",
+    border: "1px solid #444",
+    borderRadius: 4,
+    color: "#ccc",
+    fontSize: 12,
+  },
+  separator: {
+    width: 1,
+    height: 20,
+    background: "#333",
+    margin: "0 4px",
   },
   zoomButton: {
     width: 28,
@@ -256,7 +360,13 @@ const styles: Record<string, CSSProperties> = {
     cursor: "pointer",
     marginLeft: 4,
   },
+  timelineRow: {
+    display: "flex",
+    flexDirection: "row",
+    gap: 0,
+  },
   scrollContainer: {
+    flex: 1,
     overflowX: "auto",
     overflowY: "hidden",
     background: COLORS.background,
@@ -267,5 +377,13 @@ const styles: Record<string, CSSProperties> = {
   innerTrack: {
     position: "relative",
     minHeight: 40,
+  },
+  dirtyIndicator: {
+    fontSize: 12,
+    color: "#ffcc00",
+    padding: "4px 8px",
+    background: "#2a2a00",
+    borderRadius: 3,
+    alignSelf: "flex-start",
   },
 };

--- a/editor/src/components/lanes/ChordLane.tsx
+++ b/editor/src/components/lanes/ChordLane.tsx
@@ -1,14 +1,23 @@
-import { useMemo } from "react";
+import { useMemo, useCallback } from "react";
 import type { ChordEvent } from "pulsemap/schema";
 import { COLORS, LANE_HEIGHTS } from "../../constants";
 import { Lane } from "../Lane";
+import { EventBlock } from "../EventBlock";
 import { findVisibleRange } from "./visibility";
+import { useEditor } from "../../state/context";
+import {
+  selectAction,
+  moveAction,
+  resizeAction,
+} from "../../state/actions";
 
 interface ChordLaneProps {
   chords: ChordEvent[];
   scrollMs: number;
   pxPerMs: number;
   viewportWidthPx: number;
+  snapFn: (ms: number) => number;
+  snapEnabled: boolean;
 }
 
 export function ChordLane({
@@ -16,9 +25,12 @@ export function ChordLane({
   scrollMs,
   pxPerMs,
   viewportWidthPx,
+  snapFn,
+  snapEnabled,
 }: ChordLaneProps) {
   const viewportEndMs = scrollMs + viewportWidthPx / pxPerMs;
   const height = LANE_HEIGHTS.chords;
+  const { state, dispatch } = useEditor();
 
   const visibleChords = useMemo(() => {
     const [start, end] = findVisibleRange(chords, scrollMs, viewportEndMs);
@@ -26,33 +38,60 @@ export function ChordLane({
       const idx = start + i;
       const endMs =
         chord.end ?? (idx + 1 < chords.length ? chords[idx + 1].t : undefined);
-      return { ...chord, endMs };
+      return { ...chord, endMs, globalIdx: idx };
     });
   }, [chords, scrollMs, viewportEndMs]);
 
+  const handleSelect = useCallback(
+    (idx: number) => dispatch(selectAction("chords", idx)),
+    [dispatch],
+  );
+
+  const handleMove = useCallback(
+    (idx: number, beforeT: number, newT: number) => {
+      dispatch(moveAction("chords", idx, beforeT, newT));
+    },
+    [dispatch],
+  );
+
+  const handleResizeEnd = useCallback(
+    (idx: number, beforeEnd: number | undefined, newEnd: number) => {
+      dispatch(resizeAction("chords", idx, beforeEnd, newEnd));
+    },
+    [dispatch],
+  );
+
   return (
     <Lane label="Chords" height={height}>
-      {visibleChords.map((chord, i) => {
+      {visibleChords.map((chord) => {
         const x = (chord.t - scrollMs) * pxPerMs;
         const w = chord.endMs
           ? (chord.endMs - chord.t) * pxPerMs
-          : 60; // fallback width
+          : 60;
+        const selected =
+          state.selection?.lane === "chords" &&
+          state.selection?.index === chord.globalIdx;
+
         return (
-          <div
-            key={`${chord.t}-${i}`}
-            style={{
-              position: "absolute",
-              left: x,
-              top: 2,
-              width: Math.max(w, 20),
-              height: height - 4,
-              background: COLORS.chords,
-              borderRadius: 3,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              overflow: "hidden",
-            }}
+          <EventBlock
+            key={`chord-${chord.globalIdx}`}
+            x={x}
+            width={Math.max(w, 20)}
+            height={height}
+            selected={selected}
+            color={COLORS.chords}
+            startMs={chord.t}
+            endMs={chord.end}
+            pxPerMs={pxPerMs}
+            snapFn={snapFn}
+            snapEnabled={snapEnabled}
+            onClick={() => handleSelect(chord.globalIdx)}
+            onMove={(newT) => handleMove(chord.globalIdx, chord.t, newT)}
+            onResizeEnd={
+              chord.end != null
+                ? (newEnd) => handleResizeEnd(chord.globalIdx, chord.end, newEnd)
+                : undefined
+            }
           >
             <span
               style={{
@@ -60,12 +99,11 @@ export function ChordLane({
                 fontWeight: 700,
                 color: "#1a1a2e",
                 whiteSpace: "nowrap",
-                padding: "0 4px",
               }}
             >
               {chord.chord}
             </span>
-          </div>
+          </EventBlock>
         );
       })}
     </Lane>

--- a/editor/src/components/lanes/LyricLane.tsx
+++ b/editor/src/components/lanes/LyricLane.tsx
@@ -1,14 +1,23 @@
-import { useMemo } from "react";
+import { useMemo, useCallback } from "react";
 import type { LyricLine } from "pulsemap/schema";
 import { COLORS, LANE_HEIGHTS } from "../../constants";
 import { Lane } from "../Lane";
+import { EventBlock } from "../EventBlock";
 import { findVisibleRange } from "./visibility";
+import { useEditor } from "../../state/context";
+import {
+  selectAction,
+  moveAction,
+  resizeAction,
+} from "../../state/actions";
 
 interface LyricLaneProps {
   lyrics: LyricLine[];
   scrollMs: number;
   pxPerMs: number;
   viewportWidthPx: number;
+  snapFn: (ms: number) => number;
+  snapEnabled: boolean;
 }
 
 export function LyricLane({
@@ -16,9 +25,12 @@ export function LyricLane({
   scrollMs,
   pxPerMs,
   viewportWidthPx,
+  snapFn,
+  snapEnabled,
 }: LyricLaneProps) {
   const viewportEndMs = scrollMs + viewportWidthPx / pxPerMs;
   const height = LANE_HEIGHTS.lyrics;
+  const { state, dispatch } = useEditor();
 
   const visibleLyrics = useMemo(() => {
     const [start, end] = findVisibleRange(lyrics, scrollMs, viewportEndMs);
@@ -27,34 +39,60 @@ export function LyricLane({
       const endMs =
         line.end ??
         (idx + 1 < lyrics.length ? lyrics[idx + 1].t : undefined);
-      return { ...line, endMs };
+      return { ...line, endMs, globalIdx: idx };
     });
   }, [lyrics, scrollMs, viewportEndMs]);
 
+  const handleSelect = useCallback(
+    (idx: number) => dispatch(selectAction("lyrics", idx)),
+    [dispatch],
+  );
+
+  const handleMove = useCallback(
+    (idx: number, beforeT: number, newT: number) => {
+      dispatch(moveAction("lyrics", idx, beforeT, newT));
+    },
+    [dispatch],
+  );
+
+  const handleResizeEnd = useCallback(
+    (idx: number, beforeEnd: number | undefined, newEnd: number) => {
+      dispatch(resizeAction("lyrics", idx, beforeEnd, newEnd));
+    },
+    [dispatch],
+  );
+
   return (
     <Lane label="Lyrics" height={height}>
-      {visibleLyrics.map((line, i) => {
+      {visibleLyrics.map((line) => {
         const x = (line.t - scrollMs) * pxPerMs;
         const w = line.endMs
           ? (line.endMs - line.t) * pxPerMs
           : 120;
+        const selected =
+          state.selection?.lane === "lyrics" &&
+          state.selection?.index === line.globalIdx;
+
         return (
-          <div
-            key={`${line.t}-${i}`}
-            style={{
-              position: "absolute",
-              left: x,
-              top: 2,
-              width: Math.max(w, 30),
-              height: height - 4,
-              background: `${COLORS.lyrics}33`,
-              border: `1px solid ${COLORS.lyrics}66`,
-              borderRadius: 3,
-              display: "flex",
-              alignItems: "center",
-              overflow: "hidden",
-              padding: "0 4px",
-            }}
+          <EventBlock
+            key={`lyric-${line.globalIdx}`}
+            x={x}
+            width={Math.max(w, 30)}
+            height={height}
+            selected={selected}
+            color={COLORS.lyrics}
+            startMs={line.t}
+            endMs={line.end}
+            pxPerMs={pxPerMs}
+            snapFn={snapFn}
+            snapEnabled={snapEnabled}
+            onClick={() => handleSelect(line.globalIdx)}
+            onMove={(newT) => handleMove(line.globalIdx, line.t, newT)}
+            onResizeEnd={
+              line.end != null
+                ? (newEnd) => handleResizeEnd(line.globalIdx, line.end, newEnd)
+                : undefined
+            }
           >
             <span
               style={{
@@ -67,7 +105,7 @@ export function LyricLane({
             >
               {line.text}
             </span>
-          </div>
+          </EventBlock>
         );
       })}
     </Lane>

--- a/editor/src/components/lanes/SectionLane.tsx
+++ b/editor/src/components/lanes/SectionLane.tsx
@@ -1,14 +1,25 @@
-import { useMemo } from "react";
+import { useMemo, useCallback } from "react";
 import type { Section } from "pulsemap/schema";
 import { COLORS, LANE_HEIGHTS } from "../../constants";
 import { Lane } from "../Lane";
+import { EventBlock } from "../EventBlock";
 import { findVisibleRange } from "./visibility";
+import { useEditor } from "../../state/context";
+import {
+  selectAction,
+  moveAction,
+  resizeAction,
+  insertAction,
+} from "../../state/actions";
 
 interface SectionLaneProps {
   sections: Section[];
   scrollMs: number;
   pxPerMs: number;
   viewportWidthPx: number;
+  snapFn: (ms: number) => number;
+  snapEnabled: boolean;
+  durationMs: number;
 }
 
 /** Rotate through a small palette so adjacent sections differ */
@@ -28,40 +39,181 @@ export function SectionLane({
   scrollMs,
   pxPerMs,
   viewportWidthPx,
+  snapFn,
+  snapEnabled,
+  durationMs,
 }: SectionLaneProps) {
   const viewportEndMs = scrollMs + viewportWidthPx / pxPerMs;
   const height = LANE_HEIGHTS.sections;
+  const { state, dispatch } = useEditor();
 
   const visibleSections = useMemo(() => {
     const [start, end] = findVisibleRange(sections, scrollMs, viewportEndMs);
     return sections.slice(start, end).map((s, i) => ({
       ...s,
       colorIdx: (start + i) % SECTION_PALETTE.length,
+      globalIdx: start + i,
     }));
   }, [sections, scrollMs, viewportEndMs]);
 
+  const handleSelect = useCallback(
+    (idx: number) => dispatch(selectAction("sections", idx)),
+    [dispatch],
+  );
+
+  const handleMove = useCallback(
+    (idx: number, beforeT: number, newT: number) => {
+      // Clamp to adjacent section boundaries
+      const prev = idx > 0 ? sections[idx - 1] : null;
+      const next = idx + 1 < sections.length ? sections[idx + 1] : null;
+      const section = sections[idx];
+      const duration = section.end - section.t;
+
+      let clampedT = newT;
+      if (prev && clampedT < prev.end) clampedT = prev.end;
+      if (next && clampedT + duration > next.t) clampedT = next.t - duration;
+      clampedT = Math.max(0, clampedT);
+
+      dispatch(moveAction("sections", idx, beforeT, clampedT));
+    },
+    [dispatch, sections],
+  );
+
+  const handleResizeEnd = useCallback(
+    (idx: number, beforeEnd: number, newEnd: number) => {
+      // Clamp: don't overlap next section
+      const next = idx + 1 < sections.length ? sections[idx + 1] : null;
+      let clampedEnd = newEnd;
+      if (next && clampedEnd > next.t) clampedEnd = next.t;
+      clampedEnd = Math.min(clampedEnd, durationMs);
+      clampedEnd = Math.max(clampedEnd, sections[idx].t + 10); // min 10ms
+      dispatch(resizeAction("sections", idx, beforeEnd, clampedEnd));
+    },
+    [dispatch, sections, durationMs],
+  );
+
+  const handleResizeStart = useCallback(
+    (idx: number, beforeT: number, newT: number) => {
+      // Clamp: don't overlap previous section
+      const prev = idx > 0 ? sections[idx - 1] : null;
+      let clampedT = newT;
+      if (prev && clampedT < prev.end) clampedT = prev.end;
+      clampedT = Math.max(0, clampedT);
+      clampedT = Math.min(clampedT, sections[idx].end - 10);
+      dispatch(moveAction("sections", idx, beforeT, clampedT));
+    },
+    [dispatch, sections],
+  );
+
+  // Find gaps between sections for insert buttons
+  const gaps = useMemo(() => {
+    const result: { startMs: number; endMs: number; insertIdx: number }[] = [];
+    // Gap before first section
+    if (sections.length === 0 || sections[0].t > 0) {
+      result.push({
+        startMs: 0,
+        endMs: sections.length > 0 ? sections[0].t : durationMs,
+        insertIdx: 0,
+      });
+    }
+    // Gaps between sections
+    for (let i = 0; i + 1 < sections.length; i++) {
+      if (sections[i].end < sections[i + 1].t - 10) {
+        result.push({
+          startMs: sections[i].end,
+          endMs: sections[i + 1].t,
+          insertIdx: i + 1,
+        });
+      }
+    }
+    // Gap after last section
+    if (sections.length > 0 && sections[sections.length - 1].end < durationMs - 10) {
+      result.push({
+        startMs: sections[sections.length - 1].end,
+        endMs: durationMs,
+        insertIdx: sections.length,
+      });
+    }
+    return result;
+  }, [sections, durationMs]);
+
+  const handleInsert = useCallback(
+    (startMs: number, endMs: number, insertIdx: number) => {
+      const newSection: Section = {
+        t: startMs,
+        end: endMs,
+        type: "verse",
+      };
+      dispatch(insertAction("sections", insertIdx, newSection));
+    },
+    [dispatch],
+  );
+
   return (
     <Lane label="Sections" height={height}>
-      {visibleSections.map((section, i) => {
+      {/* Insert buttons for gaps */}
+      {gaps.map((gap) => {
+        const gapX = (gap.startMs - scrollMs) * pxPerMs;
+        const gapW = (gap.endMs - gap.startMs) * pxPerMs;
+        // Only show if gap is visible and wide enough
+        if (gapX + gapW < 0 || gapX > viewportWidthPx || gapW < 20) return null;
+        return (
+          <div
+            key={`gap-${gap.insertIdx}`}
+            style={{
+              position: "absolute",
+              left: gapX + gapW / 2 - 10,
+              top: height / 2 - 10,
+              width: 20,
+              height: 20,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              background: "#2a2a4a",
+              border: "1px dashed #555",
+              borderRadius: "50%",
+              cursor: "pointer",
+              fontSize: 14,
+              color: "#888",
+              zIndex: 3,
+            }}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleInsert(gap.startMs, gap.endMs, gap.insertIdx);
+            }}
+            title="Insert section"
+          >
+            +
+          </div>
+        );
+      })}
+
+      {visibleSections.map((section) => {
         const x = (section.t - scrollMs) * pxPerMs;
         const w = (section.end - section.t) * pxPerMs;
         const color = SECTION_PALETTE[section.colorIdx];
+        const selected =
+          state.selection?.lane === "sections" &&
+          state.selection?.index === section.globalIdx;
+
         return (
-          <div
-            key={`${section.t}-${i}`}
-            style={{
-              position: "absolute",
-              left: x,
-              top: 0,
-              width: Math.max(w, 20),
-              height,
-              background: `${color}33`,
-              borderLeft: `2px solid ${color}`,
-              display: "flex",
-              alignItems: "center",
-              padding: "0 6px",
-              overflow: "hidden",
-            }}
+          <EventBlock
+            key={`section-${section.globalIdx}`}
+            x={x}
+            width={Math.max(w, 20)}
+            height={height}
+            selected={selected}
+            color={color}
+            startMs={section.t}
+            endMs={section.end}
+            pxPerMs={pxPerMs}
+            snapFn={snapFn}
+            snapEnabled={snapEnabled}
+            top={0}
+            onClick={() => handleSelect(section.globalIdx)}
+            onMove={(newT) => handleMove(section.globalIdx, section.t, newT)}
+            onResizeStart={(newT) => handleResizeStart(section.globalIdx, section.t, newT)}
+            onResizeEnd={(newEnd) => handleResizeEnd(section.globalIdx, section.end, newEnd)}
           >
             <span
               style={{
@@ -70,11 +222,12 @@ export function SectionLane({
                 color: COLORS.sections,
                 whiteSpace: "nowrap",
                 textTransform: "capitalize",
+                padding: "0 2px",
               }}
             >
               {section.label ?? section.type}
             </span>
-          </div>
+          </EventBlock>
         );
       })}
     </Lane>

--- a/editor/src/components/lanes/WordLane.tsx
+++ b/editor/src/components/lanes/WordLane.tsx
@@ -1,14 +1,23 @@
-import { useMemo } from "react";
+import { useMemo, useCallback } from "react";
 import type { WordEvent } from "pulsemap/schema";
 import { COLORS, LANE_HEIGHTS } from "../../constants";
 import { Lane } from "../Lane";
+import { EventBlock } from "../EventBlock";
 import { findVisibleRange } from "./visibility";
+import { useEditor } from "../../state/context";
+import {
+  selectAction,
+  moveAction,
+  resizeAction,
+} from "../../state/actions";
 
 interface WordLaneProps {
   words: WordEvent[];
   scrollMs: number;
   pxPerMs: number;
   viewportWidthPx: number;
+  snapFn: (ms: number) => number;
+  snapEnabled: boolean;
 }
 
 export function WordLane({
@@ -16,9 +25,12 @@ export function WordLane({
   scrollMs,
   pxPerMs,
   viewportWidthPx,
+  snapFn,
+  snapEnabled,
 }: WordLaneProps) {
   const viewportEndMs = scrollMs + viewportWidthPx / pxPerMs;
   const height = LANE_HEIGHTS.words;
+  const { state, dispatch } = useEditor();
 
   const visibleWords = useMemo(() => {
     const [start, end] = findVisibleRange(words, scrollMs, viewportEndMs);
@@ -27,34 +39,60 @@ export function WordLane({
       const endMs =
         word.end ??
         (idx + 1 < words.length ? words[idx + 1].t : undefined);
-      return { ...word, endMs };
+      return { ...word, endMs, globalIdx: idx };
     });
   }, [words, scrollMs, viewportEndMs]);
 
+  const handleSelect = useCallback(
+    (idx: number) => dispatch(selectAction("words", idx)),
+    [dispatch],
+  );
+
+  const handleMove = useCallback(
+    (idx: number, beforeT: number, newT: number) => {
+      dispatch(moveAction("words", idx, beforeT, newT));
+    },
+    [dispatch],
+  );
+
+  const handleResizeEnd = useCallback(
+    (idx: number, beforeEnd: number | undefined, newEnd: number) => {
+      dispatch(resizeAction("words", idx, beforeEnd, newEnd));
+    },
+    [dispatch],
+  );
+
   return (
     <Lane label="Words" height={height}>
-      {visibleWords.map((word, i) => {
+      {visibleWords.map((word) => {
         const x = (word.t - scrollMs) * pxPerMs;
         const w = word.endMs
           ? (word.endMs - word.t) * pxPerMs
           : 40;
+        const selected =
+          state.selection?.lane === "words" &&
+          state.selection?.index === word.globalIdx;
+
         return (
-          <div
-            key={`${word.t}-${i}`}
-            style={{
-              position: "absolute",
-              left: x,
-              top: 2,
-              width: Math.max(w, 16),
-              height: height - 4,
-              background: `${COLORS.words}33`,
-              border: `1px solid ${COLORS.words}55`,
-              borderRadius: 2,
-              display: "flex",
-              alignItems: "center",
-              overflow: "hidden",
-              padding: "0 2px",
-            }}
+          <EventBlock
+            key={`word-${word.globalIdx}`}
+            x={x}
+            width={Math.max(w, 16)}
+            height={height}
+            selected={selected}
+            color={COLORS.words}
+            startMs={word.t}
+            endMs={word.end}
+            pxPerMs={pxPerMs}
+            snapFn={snapFn}
+            snapEnabled={snapEnabled}
+            onClick={() => handleSelect(word.globalIdx)}
+            onMove={(newT) => handleMove(word.globalIdx, word.t, newT)}
+            onResizeEnd={
+              word.end != null
+                ? (newEnd) => handleResizeEnd(word.globalIdx, word.end, newEnd)
+                : undefined
+            }
           >
             <span
               style={{
@@ -67,7 +105,7 @@ export function WordLane({
             >
               {word.text}
             </span>
-          </div>
+          </EventBlock>
         );
       })}
     </Lane>

--- a/editor/src/hooks/useBeatSnap.ts
+++ b/editor/src/hooks/useBeatSnap.ts
@@ -1,0 +1,110 @@
+import { useCallback, useMemo } from "react";
+import type { BeatEvent } from "pulsemap/schema";
+
+export type SnapSubdivision = "beat" | "half" | "quarter";
+
+interface UseBeatSnapOptions {
+  beats: BeatEvent[] | undefined;
+  enabled: boolean;
+  subdivision: SnapSubdivision;
+}
+
+interface UseBeatSnapResult {
+  /** Snap a ms value to the nearest beat grid point */
+  snapToNearestBeat: (ms: number) => number;
+  /** Get all snap points near a given ms (for visual indicators) */
+  getNearbySnapPoints: (ms: number, rangeMs: number) => number[];
+}
+
+/**
+ * Build a sorted array of snap points from beats at the given subdivision.
+ * beat = beat positions only
+ * half = beats + midpoints between consecutive beats
+ * quarter = beats + 1/4 points between consecutive beats
+ */
+function buildSnapGrid(beats: BeatEvent[], subdivision: SnapSubdivision): number[] {
+  if (beats.length === 0) return [];
+
+  const points: number[] = [];
+  for (let i = 0; i < beats.length; i++) {
+    points.push(beats[i].t);
+    if (i + 1 < beats.length) {
+      const gap = beats[i + 1].t - beats[i].t;
+      if (subdivision === "half" || subdivision === "quarter") {
+        points.push(beats[i].t + gap / 2);
+      }
+      if (subdivision === "quarter") {
+        points.push(beats[i].t + gap / 4);
+        points.push(beats[i].t + (3 * gap) / 4);
+      }
+    }
+  }
+  points.sort((a, b) => a - b);
+  return points;
+}
+
+/** Binary search for the nearest value in a sorted array */
+function findNearest(sorted: number[], target: number): number {
+  if (sorted.length === 0) return target;
+  if (sorted.length === 1) return sorted[0];
+
+  let lo = 0;
+  let hi = sorted.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (sorted[mid] < target) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+
+  // lo is the first element >= target. Compare lo and lo-1.
+  if (lo === 0) return sorted[0];
+  const distLo = Math.abs(sorted[lo] - target);
+  const distPrev = Math.abs(sorted[lo - 1] - target);
+  return distPrev <= distLo ? sorted[lo - 1] : sorted[lo];
+}
+
+export function useBeatSnap({
+  beats,
+  enabled,
+  subdivision,
+}: UseBeatSnapOptions): UseBeatSnapResult {
+  const snapGrid = useMemo(() => {
+    if (!enabled || !beats || beats.length === 0) return [];
+    return buildSnapGrid(beats, subdivision);
+  }, [beats, enabled, subdivision]);
+
+  const snapToNearestBeat = useCallback(
+    (ms: number): number => {
+      if (!enabled || snapGrid.length === 0) return ms;
+      return findNearest(snapGrid, ms);
+    },
+    [enabled, snapGrid],
+  );
+
+  const getNearbySnapPoints = useCallback(
+    (ms: number, rangeMs: number): number[] => {
+      if (!enabled || snapGrid.length === 0) return [];
+      // Binary search for range start
+      let lo = 0;
+      let hi = snapGrid.length;
+      const startMs = ms - rangeMs;
+      const endMs = ms + rangeMs;
+      while (lo < hi) {
+        const mid = (lo + hi) >>> 1;
+        if (snapGrid[mid] < startMs) lo = mid + 1;
+        else hi = mid;
+      }
+      const result: number[] = [];
+      for (let i = lo; i < snapGrid.length && snapGrid[i] <= endMs; i++) {
+        result.push(snapGrid[i]);
+      }
+      return result;
+    },
+    [enabled, snapGrid],
+  );
+
+  return { snapToNearestBeat, getNearbySnapPoints };
+}

--- a/editor/src/hooks/useDrag.ts
+++ b/editor/src/hooks/useDrag.ts
@@ -1,0 +1,104 @@
+import { useCallback, useRef } from "react";
+
+export type DragMode = "move" | "resize-start" | "resize-end";
+
+interface UseDragOptions {
+  pxPerMs: number;
+  snapFn: (ms: number) => number;
+  snapEnabled: boolean;
+  onDragStart?: (mode: DragMode) => void;
+  onDragMove?: (deltaMs: number, currentMs: number, mode: DragMode) => void;
+  onDragEnd?: (deltaMs: number, currentMs: number, mode: DragMode) => void;
+}
+
+interface UseDragResult {
+  /** Call this from onPointerDown to start tracking */
+  startDrag: (
+    e: React.PointerEvent,
+    mode: DragMode,
+    initialMs: number,
+  ) => void;
+  /** Whether a drag is currently in progress */
+  dragging: boolean;
+}
+
+export function useDrag({
+  pxPerMs,
+  snapFn,
+  snapEnabled,
+  onDragStart,
+  onDragMove,
+  onDragEnd,
+}: UseDragOptions): UseDragResult {
+  const draggingRef = useRef(false);
+  const modeRef = useRef<DragMode>("move");
+  const startXRef = useRef(0);
+  const initialMsRef = useRef(0);
+  const altHeldRef = useRef(false);
+
+  const handlePointerMove = useCallback(
+    (e: PointerEvent) => {
+      if (!draggingRef.current) return;
+      altHeldRef.current = e.altKey;
+      const deltaPx = e.clientX - startXRef.current;
+      const deltaMs = deltaPx / pxPerMs;
+      let currentMs = initialMsRef.current + deltaMs;
+
+      // Apply snap unless Alt is held
+      if (snapEnabled && !e.altKey) {
+        currentMs = snapFn(currentMs);
+      }
+
+      onDragMove?.(currentMs - initialMsRef.current, currentMs, modeRef.current);
+    },
+    [pxPerMs, snapFn, snapEnabled, onDragMove],
+  );
+
+  const handlePointerUp = useCallback(
+    (e: PointerEvent) => {
+      if (!draggingRef.current) return;
+      draggingRef.current = false;
+
+      const deltaPx = e.clientX - startXRef.current;
+      const deltaMs = deltaPx / pxPerMs;
+      let currentMs = initialMsRef.current + deltaMs;
+
+      if (snapEnabled && !e.altKey) {
+        currentMs = snapFn(currentMs);
+      }
+
+      onDragEnd?.(currentMs - initialMsRef.current, currentMs, modeRef.current);
+
+      (e.target as Element)?.releasePointerCapture?.(e.pointerId);
+      document.removeEventListener("pointermove", handlePointerMove);
+      document.removeEventListener("pointerup", handlePointerUp);
+    },
+    [pxPerMs, snapFn, snapEnabled, onDragEnd, handlePointerMove],
+  );
+
+  const startDrag = useCallback(
+    (e: React.PointerEvent, mode: DragMode, initialMs: number) => {
+      e.stopPropagation();
+      e.preventDefault();
+      draggingRef.current = true;
+      modeRef.current = mode;
+      startXRef.current = e.clientX;
+      initialMsRef.current = initialMs;
+      altHeldRef.current = e.altKey;
+
+      (e.target as Element).setPointerCapture(e.pointerId);
+      document.addEventListener("pointermove", handlePointerMove);
+      document.addEventListener("pointerup", handlePointerUp);
+
+      onDragStart?.(mode);
+    },
+    [onDragStart, handlePointerMove, handlePointerUp],
+  );
+
+  return {
+    startDrag,
+    get dragging() {
+      return draggingRef.current;
+    },
+  };
+}

--- a/editor/src/hooks/useKeyboardShortcuts.ts
+++ b/editor/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,127 @@
+import { useEffect } from "react";
+import { useEditor } from "../state/context";
+import {
+  undoAction,
+  redoAction,
+  deleteAction,
+  deselectAction,
+  moveAction,
+} from "../state/actions";
+import type { PulseMap } from "pulsemap/schema";
+import type { EditableLane } from "../state/types";
+
+interface UseKeyboardShortcutsOptions {
+  onPlayPause: () => void;
+  onSave: () => void;
+  snapEnabled: boolean;
+  snapFn: (ms: number) => number;
+}
+
+/** Get the event array for an editable lane */
+function getLaneEvents(map: PulseMap, lane: EditableLane): unknown[] | undefined {
+  return map[lane] as unknown[] | undefined;
+}
+
+export function useKeyboardShortcuts({
+  onPlayPause,
+  onSave,
+  snapEnabled,
+  snapFn,
+}: UseKeyboardShortcutsOptions): void {
+  const { state, dispatch } = useEditor();
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      const target = e.target as HTMLElement;
+      // Don't capture when typing in inputs
+      if (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.tagName === "SELECT" ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+
+      const isMeta = e.metaKey || e.ctrlKey;
+
+      // Space: play/pause
+      if (e.key === " " && !isMeta) {
+        e.preventDefault();
+        onPlayPause();
+        return;
+      }
+
+      // Cmd+Z: undo, Cmd+Shift+Z: redo
+      if (isMeta && e.key === "z") {
+        e.preventDefault();
+        if (e.shiftKey) {
+          dispatch(redoAction());
+        } else {
+          dispatch(undoAction());
+        }
+        return;
+      }
+
+      // Cmd+S: save
+      if (isMeta && e.key === "s") {
+        e.preventDefault();
+        onSave();
+        return;
+      }
+
+      // Delete/Backspace: delete selected event
+      if ((e.key === "Delete" || e.key === "Backspace") && state.selection) {
+        e.preventDefault();
+        const { lane, index } = state.selection;
+        const events = getLaneEvents(state.working, lane);
+        if (events && index < events.length) {
+          dispatch(deleteAction(lane, index, events[index]));
+        }
+        return;
+      }
+
+      // Escape: deselect
+      if (e.key === "Escape") {
+        dispatch(deselectAction());
+        return;
+      }
+
+      // Left/Right arrows: nudge selected event
+      if ((e.key === "ArrowLeft" || e.key === "ArrowRight") && state.selection) {
+        e.preventDefault();
+        const { lane, index } = state.selection;
+        const events = getLaneEvents(state.working, lane);
+        if (!events || index >= events.length) return;
+
+        const event = events[index] as { t: number };
+        const direction = e.key === "ArrowLeft" ? -1 : 1;
+
+        let newT: number;
+        if (snapEnabled) {
+          // Nudge by one snap grid unit
+          const testT = event.t + direction * 1; // tiny offset to find next grid point
+          const snapped = snapFn(testT);
+          // If snap didn't move us, nudge further
+          if (Math.abs(snapped - event.t) < 0.5) {
+            // Find next snap point by searching further
+            newT = snapFn(event.t + direction * 100);
+          } else {
+            newT = snapped;
+          }
+        } else {
+          newT = event.t + direction * 10;
+        }
+
+        newT = Math.max(0, newT);
+        if (newT !== event.t) {
+          dispatch(moveAction(lane, index, event.t, newT));
+        }
+        return;
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [state.selection, state.working, dispatch, onPlayPause, onSave, snapEnabled, snapFn]);
+}

--- a/editor/src/hooks/useSelection.ts
+++ b/editor/src/hooks/useSelection.ts
@@ -1,0 +1,40 @@
+import { useCallback } from "react";
+import type { EditableLane, Selection } from "../state/types";
+import { useEditor } from "../state/context";
+import { selectAction, deselectAction } from "../state/actions";
+
+interface UseSelectionResult {
+  selection: Selection | null;
+  select: (lane: EditableLane, index: number) => void;
+  deselect: () => void;
+  isSelected: (lane: EditableLane, index: number) => boolean;
+}
+
+export function useSelection(): UseSelectionResult {
+  const { state, dispatch } = useEditor();
+
+  const select = useCallback(
+    (lane: EditableLane, index: number) => {
+      dispatch(selectAction(lane, index));
+    },
+    [dispatch],
+  );
+
+  const deselect = useCallback(() => {
+    dispatch(deselectAction());
+  }, [dispatch]);
+
+  const isSelected = useCallback(
+    (lane: EditableLane, index: number) => {
+      return state.selection?.lane === lane && state.selection?.index === index;
+    },
+    [state.selection],
+  );
+
+  return {
+    selection: state.selection,
+    select,
+    deselect,
+    isSelected,
+  };
+}

--- a/editor/src/state/actions.ts
+++ b/editor/src/state/actions.ts
@@ -1,0 +1,135 @@
+import type { EditAction, EditableLane, EditorDispatchAction, Selection } from "./types";
+
+/** Move an event to a new time */
+export function moveAction(
+  lane: EditableLane,
+  index: number,
+  beforeT: number,
+  afterT: number,
+): EditorDispatchAction {
+  return {
+    type: "apply",
+    action: {
+      type: "move",
+      lane,
+      index,
+      before: { t: beforeT },
+      after: { t: afterT },
+    },
+  };
+}
+
+/** Resize an event's end time */
+export function resizeAction(
+  lane: EditableLane,
+  index: number,
+  beforeEnd: number | undefined,
+  afterEnd: number | undefined,
+): EditorDispatchAction {
+  return {
+    type: "apply",
+    action: {
+      type: "resize",
+      lane,
+      index,
+      before: { end: beforeEnd },
+      after: { end: afterEnd },
+    },
+  };
+}
+
+/** Edit a text field on an event */
+export function editTextAction(
+  lane: EditableLane,
+  index: number,
+  field: string,
+  before: string,
+  after: string,
+): EditorDispatchAction {
+  return {
+    type: "apply",
+    action: {
+      type: "edit-text",
+      lane,
+      index,
+      field,
+      before,
+      after,
+    },
+  };
+}
+
+/** Edit an arbitrary field on an event */
+export function editFieldAction(
+  lane: EditableLane,
+  index: number,
+  field: string,
+  before: unknown,
+  after: unknown,
+): EditorDispatchAction {
+  return {
+    type: "apply",
+    action: {
+      type: "edit-field",
+      lane,
+      index,
+      field,
+      before,
+      after,
+    },
+  };
+}
+
+/** Insert a new event */
+export function insertAction(
+  lane: EditableLane,
+  index: number,
+  value: unknown,
+): EditorDispatchAction {
+  return {
+    type: "apply",
+    action: {
+      type: "insert",
+      lane,
+      index,
+      value,
+    },
+  };
+}
+
+/** Delete an event */
+export function deleteAction(
+  lane: EditableLane,
+  index: number,
+  value: unknown,
+): EditorDispatchAction {
+  return {
+    type: "apply",
+    action: {
+      type: "delete",
+      lane,
+      index,
+      value,
+    },
+  };
+}
+
+/** Select an event */
+export function selectAction(lane: EditableLane, index: number): EditorDispatchAction {
+  return { type: "select", selection: { lane, index } };
+}
+
+/** Deselect */
+export function deselectAction(): EditorDispatchAction {
+  return { type: "deselect" };
+}
+
+/** Undo */
+export function undoAction(): EditorDispatchAction {
+  return { type: "undo" };
+}
+
+/** Redo */
+export function redoAction(): EditorDispatchAction {
+  return { type: "redo" };
+}

--- a/editor/src/state/context.tsx
+++ b/editor/src/state/context.tsx
@@ -1,0 +1,45 @@
+import {
+  createContext,
+  useContext,
+  useReducer,
+  useEffect,
+  type ReactNode,
+} from "react";
+import type { PulseMap } from "pulsemap/schema";
+import type { EditorState, EditorDispatchAction } from "./types";
+import { editorReducer, createInitialState } from "./reducer";
+
+interface EditorContextValue {
+  state: EditorState;
+  dispatch: (action: EditorDispatchAction) => void;
+}
+
+const EditorContext = createContext<EditorContextValue | null>(null);
+
+interface EditorProviderProps {
+  map: PulseMap;
+  children: ReactNode;
+}
+
+export function EditorProvider({ map, children }: EditorProviderProps) {
+  const [state, dispatch] = useReducer(editorReducer, map, createInitialState);
+
+  // Re-initialize when the source map changes (different map loaded)
+  useEffect(() => {
+    dispatch({ type: "load", map });
+  }, [map]);
+
+  return (
+    <EditorContext.Provider value={{ state, dispatch }}>
+      {children}
+    </EditorContext.Provider>
+  );
+}
+
+export function useEditor(): EditorContextValue {
+  const ctx = useContext(EditorContext);
+  if (!ctx) {
+    throw new Error("useEditor must be used within an EditorProvider");
+  }
+  return ctx;
+}

--- a/editor/src/state/reducer.ts
+++ b/editor/src/state/reducer.ts
@@ -1,0 +1,312 @@
+import type { PulseMap } from "pulsemap/schema";
+import type {
+  EditAction,
+  EditableLane,
+  EditorDispatchAction,
+  EditorState,
+} from "./types";
+
+/** Deep clone a PulseMap (JSON-safe) */
+function cloneMap(map: PulseMap): PulseMap {
+  return JSON.parse(JSON.stringify(map));
+}
+
+/** Get the mutable array for a lane from a PulseMap, creating it if absent */
+function getLaneArray(map: PulseMap, lane: EditableLane): unknown[] {
+  if (!map[lane]) {
+    (map as Record<string, unknown>)[lane] = [];
+  }
+  return map[lane] as unknown[];
+}
+
+/** Sort an array of timed events by t */
+function sortByT(arr: unknown[]): void {
+  arr.sort((a, b) => (a as { t: number }).t - (b as { t: number }).t);
+}
+
+/**
+ * Find the new index of an event after sorting, given its old `t` value
+ * and the new `t` value (for moves) or unchanged `t` (for other actions).
+ */
+function findIndexByT(arr: unknown[], t: number, startHint: number): number {
+  // Exact match first
+  for (let i = 0; i < arr.length; i++) {
+    if ((arr[i] as { t: number }).t === t) return i;
+  }
+  // Fallback: closest to hint
+  return Math.min(startHint, arr.length - 1);
+}
+
+/** Apply the "after" side of an action to a working map */
+function applyForward(map: PulseMap, action: EditAction): void {
+  const arr = getLaneArray(map, action.lane);
+
+  switch (action.type) {
+    case "move": {
+      const event = arr[action.index] as { t: number };
+      // Preserve duration if the event has an end
+      const asEnd = event as { t: number; end?: number };
+      if (asEnd.end != null) {
+        const duration = asEnd.end - asEnd.t;
+        asEnd.end = action.after.t + duration;
+      }
+      event.t = action.after.t;
+      break;
+    }
+    case "resize": {
+      const event = arr[action.index] as Record<string, unknown>;
+      if (action.after.end !== undefined) {
+        event.end = action.after.end;
+      } else {
+        delete event.end;
+      }
+      break;
+    }
+    case "edit-text": {
+      const event = arr[action.index] as Record<string, unknown>;
+      event[action.field] = action.after;
+      break;
+    }
+    case "edit-field": {
+      const event = arr[action.index] as Record<string, unknown>;
+      event[action.field] = action.after;
+      break;
+    }
+    case "insert": {
+      arr.splice(action.index, 0, JSON.parse(JSON.stringify(action.value)));
+      break;
+    }
+    case "delete": {
+      arr.splice(action.index, 1);
+      break;
+    }
+  }
+}
+
+/** Apply the "before" side of an action (undo) to a working map */
+function applyBackward(map: PulseMap, action: EditAction): void {
+  const arr = getLaneArray(map, action.lane);
+
+  switch (action.type) {
+    case "move": {
+      // We need to find the event at the "after" position and move it back
+      const idx = findIndexByT(arr, action.after.t, action.index);
+      const event = arr[idx] as { t: number; end?: number };
+      if (event.end != null) {
+        const duration = event.end - event.t;
+        event.end = action.before.t + duration;
+      }
+      event.t = action.before.t;
+      break;
+    }
+    case "resize": {
+      const event = arr[action.index] as Record<string, unknown>;
+      if (action.before.end !== undefined) {
+        event.end = action.before.end;
+      } else {
+        delete event.end;
+      }
+      break;
+    }
+    case "edit-text": {
+      const event = arr[action.index] as Record<string, unknown>;
+      event[action.field] = action.before;
+      break;
+    }
+    case "edit-field": {
+      const event = arr[action.index] as Record<string, unknown>;
+      event[action.field] = action.before;
+      break;
+    }
+    case "insert": {
+      // Undo insert = delete
+      arr.splice(action.index, 1);
+      break;
+    }
+    case "delete": {
+      // Undo delete = insert
+      arr.splice(
+        action.index,
+        0,
+        JSON.parse(JSON.stringify(action.value)),
+      );
+      break;
+    }
+  }
+}
+
+/**
+ * After mutating the lane array, re-sort by t and update the selection
+ * index to follow the event that was at `oldIndex` with `targetT`.
+ */
+function resortAndTrackSelection(
+  state: EditorState,
+  lane: EditableLane,
+  targetT: number,
+  oldIndex: number,
+): EditorState {
+  const arr = getLaneArray(state.working, lane);
+  sortByT(arr);
+
+  // Update selection to track the moved event
+  if (state.selection?.lane === lane) {
+    const newIdx = findIndexByT(arr, targetT, oldIndex);
+    return {
+      ...state,
+      selection: { lane, index: newIdx },
+    };
+  }
+  return state;
+}
+
+export function editorReducer(
+  state: EditorState,
+  dispatch: EditorDispatchAction,
+): EditorState {
+  switch (dispatch.type) {
+    case "load": {
+      return {
+        original: cloneMap(dispatch.map),
+        working: cloneMap(dispatch.map),
+        history: [],
+        redoStack: [],
+        selection: null,
+        dirty: false,
+      };
+    }
+
+    case "apply": {
+      const { action } = dispatch;
+      const working = cloneMap(state.working);
+      const newState: EditorState = {
+        ...state,
+        working,
+        history: [...state.history, action],
+        redoStack: [],
+        dirty: true,
+      };
+
+      applyForward(working, action);
+
+      // Determine target t for selection tracking
+      let targetT: number;
+      switch (action.type) {
+        case "move":
+          targetT = action.after.t;
+          break;
+        case "delete":
+          // Deselect on delete
+          return {
+            ...newState,
+            selection: null,
+          };
+        case "insert":
+          targetT = (action.value as { t: number }).t;
+          return resortAndTrackSelection(
+            { ...newState, selection: { lane: action.lane, index: action.index } },
+            action.lane,
+            targetT,
+            action.index,
+          );
+        default:
+          targetT = (getLaneArray(working, action.lane)[action.index] as { t: number }).t;
+          break;
+      }
+
+      return resortAndTrackSelection(newState, action.lane, targetT, action.index);
+    }
+
+    case "undo": {
+      if (state.history.length === 0) return state;
+      const action = state.history[state.history.length - 1];
+      const working = cloneMap(state.working);
+
+      applyBackward(working, action);
+
+      const newState: EditorState = {
+        ...state,
+        working,
+        history: state.history.slice(0, -1),
+        redoStack: [...state.redoStack, action],
+        dirty: state.history.length > 1,
+      };
+
+      const arr = getLaneArray(working, action.lane);
+      sortByT(arr);
+
+      // Track selection
+      if (action.type === "delete") {
+        // Undo delete: reselect the restored event
+        const targetT = (action.value as { t: number }).t;
+        const idx = findIndexByT(arr, targetT, action.index);
+        return { ...newState, selection: { lane: action.lane, index: idx } };
+      }
+      if (action.type === "insert") {
+        // Undo insert: deselect
+        return { ...newState, selection: null };
+      }
+      if (action.type === "move") {
+        const idx = findIndexByT(arr, action.before.t, action.index);
+        return { ...newState, selection: { lane: action.lane, index: idx } };
+      }
+
+      return newState;
+    }
+
+    case "redo": {
+      if (state.redoStack.length === 0) return state;
+      const action = state.redoStack[state.redoStack.length - 1];
+      const working = cloneMap(state.working);
+
+      applyForward(working, action);
+
+      const newState: EditorState = {
+        ...state,
+        working,
+        history: [...state.history, action],
+        redoStack: state.redoStack.slice(0, -1),
+        dirty: true,
+      };
+
+      const arr = getLaneArray(working, action.lane);
+      sortByT(arr);
+
+      if (action.type === "delete") {
+        return { ...newState, selection: null };
+      }
+      if (action.type === "move") {
+        const idx = findIndexByT(arr, action.after.t, action.index);
+        return { ...newState, selection: { lane: action.lane, index: idx } };
+      }
+      if (action.type === "insert") {
+        const targetT = (action.value as { t: number }).t;
+        const idx = findIndexByT(arr, targetT, action.index);
+        return { ...newState, selection: { lane: action.lane, index: idx } };
+      }
+
+      return newState;
+    }
+
+    case "select": {
+      return { ...state, selection: dispatch.selection };
+    }
+
+    case "deselect": {
+      return { ...state, selection: null };
+    }
+
+    default:
+      return state;
+  }
+}
+
+export function createInitialState(map: PulseMap): EditorState {
+  return {
+    original: cloneMap(map),
+    working: cloneMap(map),
+    history: [],
+    redoStack: [],
+    selection: null,
+    dirty: false,
+  };
+}

--- a/editor/src/state/types.ts
+++ b/editor/src/state/types.ts
@@ -1,0 +1,70 @@
+import type { PulseMap } from "pulsemap/schema";
+
+/** Lanes that support editing (beats are read-only) */
+export type EditableLane = "chords" | "words" | "lyrics" | "sections";
+
+export interface Selection {
+  lane: EditableLane;
+  index: number;
+}
+
+export type EditAction =
+  | {
+      type: "move";
+      lane: EditableLane;
+      index: number;
+      before: { t: number };
+      after: { t: number };
+    }
+  | {
+      type: "resize";
+      lane: EditableLane;
+      index: number;
+      before: { end?: number };
+      after: { end?: number };
+    }
+  | {
+      type: "edit-text";
+      lane: EditableLane;
+      index: number;
+      field: string;
+      before: string;
+      after: string;
+    }
+  | {
+      type: "edit-field";
+      lane: EditableLane;
+      index: number;
+      field: string;
+      before: unknown;
+      after: unknown;
+    }
+  | {
+      type: "insert";
+      lane: EditableLane;
+      index: number;
+      value: unknown;
+    }
+  | {
+      type: "delete";
+      lane: EditableLane;
+      index: number;
+      value: unknown;
+    };
+
+export type EditorDispatchAction =
+  | { type: "apply"; action: EditAction }
+  | { type: "undo" }
+  | { type: "redo" }
+  | { type: "select"; selection: Selection }
+  | { type: "deselect" }
+  | { type: "load"; map: PulseMap };
+
+export interface EditorState {
+  original: PulseMap;
+  working: PulseMap;
+  history: EditAction[];
+  redoStack: EditAction[];
+  selection: Selection | null;
+  dirty: boolean;
+}


### PR DESCRIPTION
## Summary

- **State management**: EditorState with undo/redo history stacks, selection tracking, and a reducer that re-sorts lane arrays by `t` after every mutation. Action creators for move, resize, edit-text, edit-field, insert, and delete operations.
- **Interaction hooks**: `useDrag` (pointer capture + snap), `useBeatSnap` (binary search grid at beat/half/quarter subdivisions), `useSelection`, `useKeyboardShortcuts` (Space, Cmd+Z/Shift+Z, Delete, Escape, arrow nudge, Cmd+S save).
- **New components**: `EventBlock` (draggable/resizable wrapper), `EditPanel` (right sidebar with typed property fields per lane type, section split/merge, keyboard shortcut reference), `SnapIndicator` (visual beat grid guides).
- **Lane updates**: All editable lanes (chords, words, lyrics, sections) now use `EventBlock` with selection and drag handlers. SectionLane adds non-overlapping clamping and gap insert buttons.
- **Timeline/App**: Flex layout with edit panel sidebar, snap toggle + subdivision selector in toolbar, dirty indicator, EditorProvider context wrapper.

## Test plan

- [ ] Load a map and verify all lanes render correctly with the new EventBlock wrappers
- [ ] Click events to select them; verify EditPanel populates with correct fields
- [ ] Drag events to move them; verify undo/redo (Cmd+Z / Cmd+Shift+Z) works
- [ ] Drag left/right edges of events with `end` values to resize
- [ ] Toggle snap on/off; verify events snap to beat grid when dragging
- [ ] Hold Alt during drag to temporarily bypass snap
- [ ] Use arrow keys to nudge selected events
- [ ] Edit text/time fields in EditPanel and verify changes apply
- [ ] Delete events with Delete/Backspace key and EditPanel delete button
- [ ] Insert sections in gaps using the "+" button
- [ ] Split and merge sections via EditPanel buttons
- [ ] Cmd+S saves to localStorage
- [ ] Typecheck passes: `cd editor && npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)