### PR TITLE
feat(editor): localStorage persistence and real-time semantic validation

### DIFF
--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { Timeline } from "./components/Timeline";
 import { TransportBar } from "./components/TransportBar";
 import { useMap } from "./hooks/useMap";
@@ -8,6 +8,12 @@ import { EditorProvider, useEditor } from "./state/context";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useBeatSnap } from "./hooks/useBeatSnap";
 import type { PulseMap } from "pulsemap/schema";
+import { hashMap } from "./persistence/hash";
+import {
+	saveEditorState,
+	loadEditorState,
+	clearEditorState,
+} from "./persistence/storage";
 
 function getMapId(): string | null {
 	const path = window.location.pathname;
@@ -38,8 +44,73 @@ function EditorContent({
 	onSeek: (ms: number) => void;
 	onRateChange: (rate: number) => void;
 }) {
-	const { state } = useEditor();
+	const { state, dispatch } = useEditor();
 	const workingMap = state.working;
+	const restoredRef = useRef(false);
+
+	// Compute and store original hash, then check for saved state
+	useEffect(() => {
+		if (restoredRef.current) return;
+		restoredRef.current = true;
+
+		hashMap(map).then((hash) => {
+			const saved = loadEditorState(map.id);
+			if (saved) {
+				if (saved.originalHash === hash) {
+					// Restore saved state
+					dispatch({
+						type: "load-saved",
+						working: saved.working,
+						history: saved.history,
+						originalHash: hash,
+					});
+				} else {
+					// Hash mismatch — upstream changed
+					const discard = window.confirm(
+						"The upstream map has been updated since your last edit. Discard local changes?",
+					);
+					if (discard) {
+						clearEditorState(map.id);
+					} else {
+						// Keep local changes even though upstream differs
+						dispatch({
+							type: "load-saved",
+							working: saved.working,
+							history: saved.history,
+							originalHash: hash,
+						});
+					}
+				}
+			}
+			// Store originalHash for auto-save even if no saved state
+			if (!saved) {
+				dispatch({
+					type: "load-saved",
+					working: map,
+					history: [],
+					originalHash: hash,
+				});
+			}
+		});
+	}, [map, dispatch]);
+
+	// Auto-save on every state change (debounced 500ms)
+	useEffect(() => {
+		if (!state.originalHash) return; // hash not yet computed
+		if (state.dirty) {
+			saveEditorState(map.id, state.working, state.history, state.originalHash);
+		}
+	}, [state.working, state.dirty, state.history, state.originalHash, map.id]);
+
+	// beforeunload warning when dirty
+	useEffect(() => {
+		if (!state.dirty) return;
+		const handler = (e: BeforeUnloadEvent) => {
+			e.preventDefault();
+		};
+		window.addEventListener("beforeunload", handler);
+		return () => window.removeEventListener("beforeunload", handler);
+	}, [state.dirty]);
 
 	const { snapToNearestBeat } = useBeatSnap({
 		beats: workingMap.beats,
@@ -56,16 +127,9 @@ function EditorContent({
 	}, [playing, onPlay, onPause]);
 
 	const handleSave = useCallback(() => {
-		if (!state.dirty) return;
-		try {
-			localStorage.setItem(
-				`pulsemap-edit-${workingMap.id}`,
-				JSON.stringify(workingMap),
-			);
-		} catch {
-			// localStorage might be full or unavailable
-		}
-	}, [state.dirty, workingMap]);
+		if (!state.dirty || !state.originalHash) return;
+		saveEditorState(map.id, state.working, state.history, state.originalHash);
+	}, [state.dirty, state.working, state.history, state.originalHash, map.id]);
 
 	useKeyboardShortcuts({
 		onPlayPause: handlePlayPause,

--- a/editor/src/components/DirtyIndicator.tsx
+++ b/editor/src/components/DirtyIndicator.tsx
@@ -1,0 +1,34 @@
+import type { CSSProperties } from "react";
+
+interface DirtyIndicatorProps {
+  dirty: boolean;
+  editCount: number;
+}
+
+export function DirtyIndicator({ dirty, editCount }: DirtyIndicatorProps) {
+  if (!dirty) return null;
+
+  return (
+    <span style={styles.indicator}>
+      <span style={styles.dot} />
+      Unsaved ({editCount} edit{editCount !== 1 ? "s" : ""})
+    </span>
+  );
+}
+
+const styles: Record<string, CSSProperties> = {
+  indicator: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 4,
+    fontSize: 12,
+    color: "#ffcc00",
+  },
+  dot: {
+    display: "inline-block",
+    width: 6,
+    height: 6,
+    borderRadius: "50%",
+    background: "#ffcc00",
+  },
+};

--- a/editor/src/components/EventBlock.tsx
+++ b/editor/src/components/EventBlock.tsx
@@ -36,6 +36,8 @@ interface EventBlockProps {
   onDoubleClick?: () => void;
   /** Top offset within the lane */
   top?: number;
+  /** Override border color (for validation indicators) */
+  borderColor?: string;
 }
 
 const RESIZE_HANDLE_WIDTH = 6;
@@ -58,6 +60,7 @@ export function EventBlock({
   onResizeEnd,
   onDoubleClick,
   top = 2,
+  borderColor: borderColorOverride,
 }: EventBlockProps) {
   const [dragOffset, setDragOffset] = useState<{ dx: number; mode: DragMode } | null>(null);
   const blockRef = useRef<HTMLDivElement>(null);
@@ -145,7 +148,7 @@ export function EventBlock({
     }
   }
 
-  const borderColor = selected ? "#fff" : `${color}66`;
+  const borderColor = borderColorOverride ?? (selected ? "#fff" : `${color}66`);
 
   const style: CSSProperties = {
     position: "absolute",

--- a/editor/src/components/ExportButton.tsx
+++ b/editor/src/components/ExportButton.tsx
@@ -1,0 +1,37 @@
+import type { CSSProperties } from "react";
+import type { PulseMap } from "pulsemap/schema";
+
+interface ExportButtonProps {
+  map: PulseMap;
+}
+
+export function ExportButton({ map }: ExportButtonProps) {
+  const handleExport = () => {
+    const json = JSON.stringify(map, null, 2);
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${map.id}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <button type="button" style={styles.button} onClick={handleExport}>
+      Export JSON
+    </button>
+  );
+}
+
+const styles: Record<string, CSSProperties> = {
+  button: {
+    padding: "4px 10px",
+    background: "#1a3a2a",
+    border: "1px solid #3a6a4a",
+    borderRadius: 4,
+    color: "#6fdc8c",
+    fontSize: 12,
+    cursor: "pointer",
+  },
+};

--- a/editor/src/components/Timeline.tsx
+++ b/editor/src/components/Timeline.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect, type CSSProperties } from "react";
+import { useState, useCallback, useRef, useEffect, useMemo, type CSSProperties } from "react";
 import type { PulseMap } from "pulsemap/schema";
 import { useTimeline } from "../hooks/useTimeline";
 import { useBeatSnap, type SnapSubdivision } from "../hooks/useBeatSnap";
@@ -13,6 +13,12 @@ import { ChordLane } from "./lanes/ChordLane";
 import { LyricLane } from "./lanes/LyricLane";
 import { WordLane } from "./lanes/WordLane";
 import { SectionLane } from "./lanes/SectionLane";
+import { DirtyIndicator } from "./DirtyIndicator";
+import { ExportButton } from "./ExportButton";
+import { ValidationPanel } from "./ValidationPanel";
+import { validateMap } from "../validation/validate";
+import type { ValidationIssue } from "../validation/types";
+import type { EditableLane } from "../state/types";
 
 interface TimelineProps {
   map: PulseMap;
@@ -82,6 +88,38 @@ export function Timeline({ map, position, playing, onSeek }: TimelineProps) {
     [snapEnabled, snapToNearestBeat],
   );
 
+  // -- Validation --
+  const validationIssues: ValidationIssue[] = useMemo(
+    () => validateMap(workingMap),
+    [workingMap],
+  );
+
+  const errorCount = useMemo(
+    () => validationIssues.filter((i) => i.severity === "error").length,
+    [validationIssues],
+  );
+
+  const canSubmit = errorCount === 0;
+
+  /** Build per-lane Maps of index -> border color for validation */
+  const validationColorsByLane = useMemo(() => {
+    const map = new Map<EditableLane, Map<number, string>>();
+    for (const issue of validationIssues) {
+      if (issue.lane == null || issue.index == null) continue;
+      if (!map.has(issue.lane)) map.set(issue.lane, new Map());
+      const laneMap = map.get(issue.lane)!;
+      // error trumps warning
+      const existing = laneMap.get(issue.index);
+      if (!existing || (existing !== "#ff4444" && issue.severity === "error")) {
+        laneMap.set(
+          issue.index,
+          issue.severity === "error" ? "#ff4444" : "#ffaa00",
+        );
+      }
+    }
+    return map;
+  }, [validationIssues]);
+
   // Measure viewport width
   useEffect(() => {
     const el = measureRef.current;
@@ -135,11 +173,20 @@ export function Timeline({ map, position, playing, onSeek }: TimelineProps) {
     <div style={styles.outerWrapper}>
       <div style={styles.wrapper}>
         <div style={styles.toolbar}>
-          <LaneToggles
-            map={workingMap}
-            visibility={visibility}
-            onToggle={toggleLane}
-          />
+          <div style={styles.toolbarLeft}>
+            <LaneToggles
+              map={workingMap}
+              visibility={visibility}
+              onToggle={toggleLane}
+            />
+            <DirtyIndicator dirty={state.dirty} editCount={state.history.length} />
+            {state.dirty && <ExportButton map={workingMap} />}
+            {!canSubmit && (
+              <span style={styles.submitGate}>
+                {errorCount} error{errorCount !== 1 ? "s" : ""} — fix before submitting
+              </span>
+            )}
+          </div>
           <div style={styles.toolbarRight}>
             {/* Snap controls */}
             <button
@@ -211,6 +258,7 @@ export function Timeline({ map, position, playing, onSeek }: TimelineProps) {
                         snapFn={snapFn}
                         snapEnabled={snapEnabled}
                         durationMs={workingMap.duration_ms}
+                        validationColors={validationColorsByLane.get("sections")}
                       />
                     );
                   case "lyrics":
@@ -223,6 +271,7 @@ export function Timeline({ map, position, playing, onSeek }: TimelineProps) {
                         viewportWidthPx={contentViewportWidth}
                         snapFn={snapFn}
                         snapEnabled={snapEnabled}
+                        validationColors={validationColorsByLane.get("lyrics")}
                       />
                     );
                   case "words":
@@ -235,6 +284,7 @@ export function Timeline({ map, position, playing, onSeek }: TimelineProps) {
                         viewportWidthPx={contentViewportWidth}
                         snapFn={snapFn}
                         snapEnabled={snapEnabled}
+                        validationColors={validationColorsByLane.get("words")}
                       />
                     );
                   case "chords":
@@ -247,6 +297,7 @@ export function Timeline({ map, position, playing, onSeek }: TimelineProps) {
                         viewportWidthPx={contentViewportWidth}
                         snapFn={snapFn}
                         snapEnabled={snapEnabled}
+                        validationColors={validationColorsByLane.get("chords")}
                       />
                     );
                   case "beats":
@@ -268,10 +319,8 @@ export function Timeline({ map, position, playing, onSeek }: TimelineProps) {
         </div>
       </div>
 
-      {state.dirty && (
-        <div style={styles.dirtyIndicator}>
-          Unsaved changes ({state.history.length} edit{state.history.length !== 1 ? "s" : ""})
-        </div>
+      {validationIssues.length > 0 && (
+        <ValidationPanel issues={validationIssues} dispatch={dispatch} />
       )}
     </div>
   );
@@ -296,10 +345,21 @@ const styles: Record<string, CSSProperties> = {
     flexWrap: "wrap",
     gap: 8,
   },
+  toolbarLeft: {
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+    flexWrap: "wrap",
+  },
   toolbarRight: {
     display: "flex",
     alignItems: "center",
     gap: 6,
+  },
+  submitGate: {
+    fontSize: 11,
+    color: "#ff4444",
+    fontWeight: 600,
   },
   snapButton: {
     padding: "4px 10px",
@@ -377,13 +437,5 @@ const styles: Record<string, CSSProperties> = {
   innerTrack: {
     position: "relative",
     minHeight: 40,
-  },
-  dirtyIndicator: {
-    fontSize: 12,
-    color: "#ffcc00",
-    padding: "4px 8px",
-    background: "#2a2a00",
-    borderRadius: 3,
-    alignSelf: "flex-start",
   },
 };

--- a/editor/src/components/ValidationPanel.tsx
+++ b/editor/src/components/ValidationPanel.tsx
@@ -1,0 +1,139 @@
+import { useCallback, type CSSProperties } from "react";
+import type { ValidationIssue } from "../validation/types";
+import type { EditorDispatchAction } from "../state/types";
+
+interface ValidationPanelProps {
+  issues: ValidationIssue[];
+  dispatch: (action: EditorDispatchAction) => void;
+}
+
+export function ValidationPanel({ issues, dispatch }: ValidationPanelProps) {
+  const errors = issues.filter((i) => i.severity === "error");
+  const warnings = issues.filter((i) => i.severity === "warning");
+
+  const handleClick = useCallback(
+    (issue: ValidationIssue) => {
+      if (issue.lane != null && issue.index != null) {
+        dispatch({
+          type: "select",
+          selection: { lane: issue.lane, index: issue.index },
+        });
+      }
+    },
+    [dispatch],
+  );
+
+  if (issues.length === 0) {
+    return (
+      <div style={styles.panel}>
+        <div style={styles.clean}>No issues</div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={styles.panel}>
+      <div style={styles.summary}>
+        {errors.length > 0 && (
+          <span style={styles.errorCount}>
+            {errors.length} error{errors.length !== 1 ? "s" : ""}
+          </span>
+        )}
+        {warnings.length > 0 && (
+          <span style={styles.warningCount}>
+            {warnings.length} warning{warnings.length !== 1 ? "s" : ""}
+          </span>
+        )}
+      </div>
+      <div style={styles.list}>
+        {issues.map((issue, i) => (
+          <div
+            key={`${issue.lane ?? "map"}-${issue.index ?? "x"}-${i}`}
+            style={{
+              ...styles.item,
+              cursor: issue.lane != null && issue.index != null ? "pointer" : "default",
+            }}
+            onClick={() => handleClick(issue)}
+          >
+            <span
+              style={{
+                ...styles.icon,
+                color: issue.severity === "error" ? "#ff4444" : "#ffaa00",
+              }}
+            >
+              {issue.severity === "error" ? "●" : "▲"}
+            </span>
+            <span style={styles.msg}>
+              {issue.lane && (
+                <span style={styles.lane}>{issue.lane}</span>
+              )}
+              {issue.index != null && (
+                <span style={styles.idx}>#{issue.index}</span>
+              )}
+              {issue.message}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const styles: Record<string, CSSProperties> = {
+  panel: {
+    fontSize: 12,
+    color: "#ccc",
+  },
+  clean: {
+    color: "#4ade80",
+    fontSize: 12,
+    padding: "4px 0",
+  },
+  summary: {
+    display: "flex",
+    gap: 10,
+    padding: "4px 0 6px",
+  },
+  errorCount: {
+    color: "#ff4444",
+    fontWeight: 600,
+  },
+  warningCount: {
+    color: "#ffaa00",
+    fontWeight: 600,
+  },
+  list: {
+    display: "flex",
+    flexDirection: "column",
+    gap: 2,
+    maxHeight: 160,
+    overflowY: "auto",
+  },
+  item: {
+    display: "flex",
+    alignItems: "flex-start",
+    gap: 6,
+    padding: "3px 6px",
+    borderRadius: 3,
+    lineHeight: "1.3",
+  },
+  icon: {
+    flexShrink: 0,
+    fontSize: 10,
+    marginTop: 2,
+  },
+  msg: {
+    display: "inline",
+  },
+  lane: {
+    fontWeight: 600,
+    textTransform: "capitalize" as const,
+    marginRight: 4,
+  },
+  idx: {
+    color: "#888",
+    fontFamily: "monospace",
+    fontSize: 11,
+    marginRight: 4,
+  },
+};

--- a/editor/src/components/lanes/ChordLane.tsx
+++ b/editor/src/components/lanes/ChordLane.tsx
@@ -18,6 +18,8 @@ interface ChordLaneProps {
   viewportWidthPx: number;
   snapFn: (ms: number) => number;
   snapEnabled: boolean;
+  /** Per-index border color override for validation indicators */
+  validationColors?: Map<number, string>;
 }
 
 export function ChordLane({
@@ -27,6 +29,7 @@ export function ChordLane({
   viewportWidthPx,
   snapFn,
   snapEnabled,
+  validationColors,
 }: ChordLaneProps) {
   const viewportEndMs = scrollMs + viewportWidthPx / pxPerMs;
   const height = LANE_HEIGHTS.chords;
@@ -87,6 +90,7 @@ export function ChordLane({
             snapEnabled={snapEnabled}
             onClick={() => handleSelect(chord.globalIdx)}
             onMove={(newT) => handleMove(chord.globalIdx, chord.t, newT)}
+            borderColor={validationColors?.get(chord.globalIdx)}
             onResizeEnd={
               chord.end != null
                 ? (newEnd) => handleResizeEnd(chord.globalIdx, chord.end, newEnd)

--- a/editor/src/components/lanes/LyricLane.tsx
+++ b/editor/src/components/lanes/LyricLane.tsx
@@ -18,6 +18,8 @@ interface LyricLaneProps {
   viewportWidthPx: number;
   snapFn: (ms: number) => number;
   snapEnabled: boolean;
+  /** Per-index border color override for validation indicators */
+  validationColors?: Map<number, string>;
 }
 
 export function LyricLane({
@@ -27,6 +29,7 @@ export function LyricLane({
   viewportWidthPx,
   snapFn,
   snapEnabled,
+  validationColors,
 }: LyricLaneProps) {
   const viewportEndMs = scrollMs + viewportWidthPx / pxPerMs;
   const height = LANE_HEIGHTS.lyrics;
@@ -88,6 +91,7 @@ export function LyricLane({
             snapEnabled={snapEnabled}
             onClick={() => handleSelect(line.globalIdx)}
             onMove={(newT) => handleMove(line.globalIdx, line.t, newT)}
+            borderColor={validationColors?.get(line.globalIdx)}
             onResizeEnd={
               line.end != null
                 ? (newEnd) => handleResizeEnd(line.globalIdx, line.end, newEnd)

--- a/editor/src/components/lanes/SectionLane.tsx
+++ b/editor/src/components/lanes/SectionLane.tsx
@@ -20,6 +20,8 @@ interface SectionLaneProps {
   snapFn: (ms: number) => number;
   snapEnabled: boolean;
   durationMs: number;
+  /** Per-index border color override for validation indicators */
+  validationColors?: Map<number, string>;
 }
 
 /** Rotate through a small palette so adjacent sections differ */
@@ -42,6 +44,7 @@ export function SectionLane({
   snapFn,
   snapEnabled,
   durationMs,
+  validationColors,
 }: SectionLaneProps) {
   const viewportEndMs = scrollMs + viewportWidthPx / pxPerMs;
   const height = LANE_HEIGHTS.sections;
@@ -209,6 +212,7 @@ export function SectionLane({
             pxPerMs={pxPerMs}
             snapFn={snapFn}
             snapEnabled={snapEnabled}
+            borderColor={validationColors?.get(section.globalIdx)}
             top={0}
             onClick={() => handleSelect(section.globalIdx)}
             onMove={(newT) => handleMove(section.globalIdx, section.t, newT)}

--- a/editor/src/components/lanes/WordLane.tsx
+++ b/editor/src/components/lanes/WordLane.tsx
@@ -18,6 +18,8 @@ interface WordLaneProps {
   viewportWidthPx: number;
   snapFn: (ms: number) => number;
   snapEnabled: boolean;
+  /** Per-index border color override for validation indicators */
+  validationColors?: Map<number, string>;
 }
 
 export function WordLane({
@@ -27,6 +29,7 @@ export function WordLane({
   viewportWidthPx,
   snapFn,
   snapEnabled,
+  validationColors,
 }: WordLaneProps) {
   const viewportEndMs = scrollMs + viewportWidthPx / pxPerMs;
   const height = LANE_HEIGHTS.words;
@@ -88,6 +91,7 @@ export function WordLane({
             snapEnabled={snapEnabled}
             onClick={() => handleSelect(word.globalIdx)}
             onMove={(newT) => handleMove(word.globalIdx, word.t, newT)}
+            borderColor={validationColors?.get(word.globalIdx)}
             onResizeEnd={
               word.end != null
                 ? (newEnd) => handleResizeEnd(word.globalIdx, word.end, newEnd)

--- a/editor/src/persistence/hash.ts
+++ b/editor/src/persistence/hash.ts
@@ -1,0 +1,11 @@
+/** SHA-256 hash of a PulseMap via crypto.subtle */
+import type { PulseMap } from "pulsemap/schema";
+
+export async function hashMap(map: PulseMap): Promise<string> {
+  const data = new TextEncoder().encode(JSON.stringify(map));
+  const buffer = await crypto.subtle.digest("SHA-256", data);
+  const bytes = new Uint8Array(buffer);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/editor/src/persistence/storage.ts
+++ b/editor/src/persistence/storage.ts
@@ -1,0 +1,73 @@
+/**
+ * localStorage persistence for editor state.
+ *
+ * Key format: `pulsemap-edit:${mapId}`
+ * Payload: working map, edit history, save timestamp, and
+ * a hash of the original (upstream) map so we can detect
+ * upstream changes on reload.
+ */
+import type { PulseMap } from "pulsemap/schema";
+import type { EditAction } from "../state/types";
+
+export interface SavedEditorState {
+  working: PulseMap;
+  history: EditAction[];
+  savedAt: number;
+  originalHash: string;
+}
+
+function storageKey(mapId: string): string {
+  return `pulsemap-edit:${mapId}`;
+}
+
+/** Read saved editor state from localStorage. Returns null on miss or corruption. */
+export function loadEditorState(mapId: string): SavedEditorState | null {
+  try {
+    const raw = localStorage.getItem(storageKey(mapId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as SavedEditorState;
+    // Basic shape check
+    if (!parsed.working || !Array.isArray(parsed.history) || !parsed.originalHash) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** Remove saved editor state for a map. */
+export function clearEditorState(mapId: string): void {
+  try {
+    localStorage.removeItem(storageKey(mapId));
+  } catch {
+    // localStorage may be unavailable
+  }
+}
+
+// -- Debounced save -----------------------------------------------------------
+
+let saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+/** Debounced (500ms) write of editor state to localStorage. */
+export function saveEditorState(
+  mapId: string,
+  working: PulseMap,
+  history: EditAction[],
+  originalHash: string,
+): void {
+  if (saveTimer) clearTimeout(saveTimer);
+  saveTimer = setTimeout(() => {
+    try {
+      const payload: SavedEditorState = {
+        working,
+        history,
+        savedAt: Date.now(),
+        originalHash,
+      };
+      localStorage.setItem(storageKey(mapId), JSON.stringify(payload));
+    } catch {
+      // localStorage may be full or unavailable
+    }
+  }, 500);
+}

--- a/editor/src/state/reducer.ts
+++ b/editor/src/state/reducer.ts
@@ -172,6 +172,19 @@ export function editorReducer(
         redoStack: [],
         selection: null,
         dirty: false,
+        originalHash: "",
+      };
+    }
+
+    case "load-saved": {
+      return {
+        ...state,
+        working: cloneMap(dispatch.working),
+        history: [...dispatch.history],
+        redoStack: [],
+        selection: null,
+        dirty: dispatch.history.length > 0,
+        originalHash: dispatch.originalHash,
       };
     }
 
@@ -308,5 +321,6 @@ export function createInitialState(map: PulseMap): EditorState {
     redoStack: [],
     selection: null,
     dirty: false,
+    originalHash: "",
   };
 }

--- a/editor/src/state/types.ts
+++ b/editor/src/state/types.ts
@@ -58,7 +58,8 @@ export type EditorDispatchAction =
   | { type: "redo" }
   | { type: "select"; selection: Selection }
   | { type: "deselect" }
-  | { type: "load"; map: PulseMap };
+  | { type: "load"; map: PulseMap }
+  | { type: "load-saved"; working: PulseMap; history: EditAction[]; originalHash: string };
 
 export interface EditorState {
   original: PulseMap;
@@ -67,4 +68,5 @@ export interface EditorState {
   redoStack: EditAction[];
   selection: Selection | null;
   dirty: boolean;
+  originalHash: string;
 }

--- a/editor/src/validation/types.ts
+++ b/editor/src/validation/types.ts
@@ -1,0 +1,8 @@
+import type { EditableLane } from "../state/types";
+
+export interface ValidationIssue {
+  severity: "error" | "warning";
+  lane?: EditableLane;
+  index?: number;
+  message: string;
+}

--- a/editor/src/validation/validate.ts
+++ b/editor/src/validation/validate.ts
@@ -1,0 +1,138 @@
+/**
+ * Semantic validation of a working PulseMap.
+ * Runs after every edit; returns an array of issues.
+ */
+import { Value } from "@sinclair/typebox/value";
+import { PulseMapSchema, type PulseMap, type Section } from "pulsemap/schema";
+import type { EditableLane } from "../state/types";
+import type { ValidationIssue } from "./types";
+
+/** Chord name regex: starts with A-G, optional # or b */
+const CHORD_ROOT_RE = /^[A-G][#b]?/;
+
+export function validateMap(map: PulseMap): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+  const duration = map.duration_ms;
+
+  // 1. Schema check
+  if (!Value.Check(PulseMapSchema, map)) {
+    issues.push({
+      severity: "error",
+      message: "Map fails schema validation",
+    });
+  }
+
+  // Helper: check timestamp range
+  function checkRange(
+    lane: EditableLane,
+    arr: { t: number; end?: number }[] | undefined,
+  ) {
+    if (!arr) return;
+    for (let i = 0; i < arr.length; i++) {
+      const ev = arr[i];
+      if (ev.t < 0 || ev.t > duration) {
+        issues.push({
+          severity: "error",
+          lane,
+          index: i,
+          message: `Start time ${ev.t}ms is outside [0, ${duration}]`,
+        });
+      }
+      if (ev.end != null) {
+        if (ev.end < 0 || ev.end > duration) {
+          issues.push({
+            severity: "error",
+            lane,
+            index: i,
+            message: `End time ${ev.end}ms is outside [0, ${duration}]`,
+          });
+        }
+        // 5. end > t
+        if (ev.end <= ev.t) {
+          issues.push({
+            severity: "error",
+            lane,
+            index: i,
+            message: `End time (${ev.end}ms) must be after start (${ev.t}ms)`,
+          });
+        }
+      }
+    }
+  }
+
+  // 2. Timestamp range checks
+  checkRange("chords", map.chords as { t: number; end?: number }[] | undefined);
+  checkRange("words", map.words as { t: number; end?: number }[] | undefined);
+  checkRange("lyrics", map.lyrics as { t: number; end?: number }[] | undefined);
+  checkRange("sections", map.sections as { t: number; end?: number }[] | undefined);
+
+  // 3. Non-overlapping sections
+  if (map.sections && map.sections.length > 1) {
+    const secs = map.sections as Section[];
+    for (let i = 0; i + 1 < secs.length; i++) {
+      if (secs[i].end > secs[i + 1].t) {
+        issues.push({
+          severity: "error",
+          lane: "sections",
+          index: i,
+          message: `Section overlaps with next (end ${secs[i].end}ms > next start ${secs[i + 1].t}ms)`,
+        });
+      }
+    }
+  }
+
+  // 4. Non-empty text
+  if (map.words) {
+    for (let i = 0; i < map.words.length; i++) {
+      if (!map.words[i].text || map.words[i].text.trim() === "") {
+        issues.push({
+          severity: "error",
+          lane: "words",
+          index: i,
+          message: "Word text is empty",
+        });
+      }
+    }
+  }
+  if (map.lyrics) {
+    for (let i = 0; i < map.lyrics.length; i++) {
+      if (!map.lyrics[i].text || map.lyrics[i].text.trim() === "") {
+        issues.push({
+          severity: "error",
+          lane: "lyrics",
+          index: i,
+          message: "Lyric line text is empty",
+        });
+      }
+    }
+  }
+  if (map.chords) {
+    for (let i = 0; i < map.chords.length; i++) {
+      if (!map.chords[i].chord || map.chords[i].chord.trim() === "") {
+        issues.push({
+          severity: "error",
+          lane: "chords",
+          index: i,
+          message: "Chord name is empty",
+        });
+      }
+    }
+  }
+
+  // 6. Chord name format warning
+  if (map.chords) {
+    for (let i = 0; i < map.chords.length; i++) {
+      const name = map.chords[i].chord;
+      if (name && !CHORD_ROOT_RE.test(name)) {
+        issues.push({
+          severity: "warning",
+          lane: "chords",
+          index: i,
+          message: `Chord "${name}" doesn't start with a standard root (A-G)`,
+        });
+      }
+    }
+  }
+
+  return issues;
+}


### PR DESCRIPTION
## Summary
- **localStorage persistence (C4):** Auto-save working map + edit history (debounced 500ms), restore on reload with SHA-256 upstream change detection, beforeunload warning, Export JSON button, DirtyIndicator component
- **Real-time semantic validation (C5):** Validates on every edit (schema check, timestamp ranges, section overlaps, empty text, end > start, chord name format), ValidationPanel with clickable issues, red/amber border indicators on timeline events, pre-submission gate (`canSubmit` boolean for C6)

## Test plan
- [ ] Make edits, reload page — edits should restore from localStorage
- [ ] Edit a map, change the upstream JSON, reload — should prompt about discarding local changes
- [ ] Verify Export JSON downloads a valid map file
- [ ] Create invalid state (drag event past duration, empty chord name) — red borders appear on timeline, issues listed in ValidationPanel
- [ ] Click a validation issue — selects the event in the EditPanel
- [ ] Verify "fix before submitting" gate appears when errors exist
- [ ] beforeunload fires when navigating away with unsaved edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)