### PR TITLE
feat(editor): GitHub OAuth and PR submission with diff review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,10 @@ Maps are JSON files describing the structure of a recording:
   `chords`, `beats`, `sections`, `midi`, `analysis`
 - `lyrics` and `words` are independent peer arrays (Model C). `lyrics`
   has line-level text from lyric databases. `words` has per-word
-  timestamps from forced alignment. A map can have one, both, or neither.
+  timestamps from WhisperX transcription. A map can have one, both,
+  or neither. Note: LRCLIB `end` timestamps on lyric lines are
+  unreliable — they're always "next line start," not when the vocal
+  actually ends. The `words` array is the authoritative timing source.
 - Source-agnostic: same map works across YouTube, Spotify, local files
 - Musical data is transposable at render time (chords as standard names,
   MIDI as pitch numbers)

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -1,19 +1,16 @@
-import { useCallback, useEffect, useRef } from "react";
+import type { PulseMap } from "pulsemap/schema";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Timeline } from "./components/Timeline";
 import { TransportBar } from "./components/TransportBar";
+import { getStoredToken, handleCallback, storeToken, validateToken } from "./github/auth";
+import { useBeatSnap } from "./hooks/useBeatSnap";
+import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useMap } from "./hooks/useMap";
 import { usePlayback } from "./hooks/usePlayback";
-import { parseEditorParams } from "./types";
-import { EditorProvider, useEditor } from "./state/context";
-import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
-import { useBeatSnap } from "./hooks/useBeatSnap";
-import type { PulseMap } from "pulsemap/schema";
 import { hashMap } from "./persistence/hash";
-import {
-	saveEditorState,
-	loadEditorState,
-	clearEditorState,
-} from "./persistence/storage";
+import { clearEditorState, loadEditorState, saveEditorState } from "./persistence/storage";
+import { EditorProvider, useEditor } from "./state/context";
+import { parseEditorParams } from "./types";
 
 function getMapId(): string | null {
 	const path = window.location.pathname;
@@ -33,6 +30,9 @@ function EditorContent({
 	onPause,
 	onSeek,
 	onRateChange,
+	ghToken,
+	ghLogin,
+	onAuthChange,
 }: {
 	map: PulseMap;
 	playing: boolean;
@@ -43,6 +43,9 @@ function EditorContent({
 	onPause: () => void;
 	onSeek: (ms: number) => void;
 	onRateChange: (rate: number) => void;
+	ghToken: string | null;
+	ghLogin: string | null;
+	onAuthChange: (token: string | null, login: string | null) => void;
 }) {
 	const { state, dispatch } = useEditor();
 	const workingMap = state.working;
@@ -172,6 +175,10 @@ function EditorContent({
 				position={position}
 				playing={playing}
 				onSeek={onSeek}
+				ghToken={ghToken}
+				ghLogin={ghLogin}
+				onAuthChange={onAuthChange}
+				playbackAvailable={playbackAvailable}
 			/>
 
 			<div style={styles.debugInfo}>
@@ -196,6 +203,63 @@ export function App() {
 	const { map, loading, error } = useMap(mapId);
 	const { containerId, play, pause, seek, setRate, playbackAvailable, playing, position } =
 		usePlayback(map);
+
+	// --- GitHub OAuth state ---
+	const [ghToken, setGhToken] = useState<string | null>(null);
+	const [ghLogin, setGhLogin] = useState<string | null>(null);
+	const callbackHandled = useRef(false);
+
+	// Handle OAuth callback: ?code=... in the URL
+	useEffect(() => {
+		if (callbackHandled.current) return;
+		const urlParams = new URLSearchParams(window.location.search);
+		const code = urlParams.get("code");
+		if (!code) return;
+
+		callbackHandled.current = true;
+
+		handleCallback(code)
+			.then((token) => {
+				storeToken(token);
+				setGhToken(token);
+				return validateToken(token);
+			})
+			.then((user) => {
+				if (user) setGhLogin(user.login);
+				// Clean the URL — remove code param
+				const clean = new URL(window.location.href);
+				clean.searchParams.delete("code");
+				window.history.replaceState({}, "", clean.toString());
+			})
+			.catch((err) => {
+				console.error("OAuth callback failed:", err);
+				// Clean the URL anyway
+				const clean = new URL(window.location.href);
+				clean.searchParams.delete("code");
+				window.history.replaceState({}, "", clean.toString());
+			});
+	}, []);
+
+	// Initialize from stored token (no callback)
+	const tokenInitialized = useRef(false);
+	useEffect(() => {
+		if (tokenInitialized.current) return;
+		tokenInitialized.current = true;
+		const token = getStoredToken();
+		if (token) {
+			validateToken(token).then((user) => {
+				if (user) {
+					setGhToken(token);
+					setGhLogin(user.login);
+				}
+			});
+		}
+	}, []);
+
+	const handleAuthChange = useCallback((token: string | null, login: string | null) => {
+		setGhToken(token);
+		setGhLogin(login);
+	}, []);
 
 	// Seek to ?t= param on first load
 	if (params.t != null && map && playbackAvailable && position === 0) {
@@ -248,6 +312,9 @@ export function App() {
 					onPause={pause}
 					onSeek={seek}
 					onRateChange={setRate}
+					ghToken={ghToken}
+					ghLogin={ghLogin}
+					onAuthChange={handleAuthChange}
 				/>
 			</EditorProvider>
 		</div>

--- a/editor/src/components/DiffReview.tsx
+++ b/editor/src/components/DiffReview.tsx
@@ -1,0 +1,140 @@
+import { type CSSProperties, useCallback } from "react";
+import type { DiffChange } from "../github/diff";
+
+interface DiffReviewProps {
+	changes: DiffChange[];
+	checkedIndices: Set<number>;
+	onToggle: (index: number) => void;
+	playbackAvailable: boolean;
+	errorCount: number;
+}
+
+export function DiffReview({
+	changes,
+	checkedIndices,
+	onToggle,
+	playbackAvailable,
+	errorCount,
+}: DiffReviewProps) {
+	// Per-field summary
+	const fieldCounts: Record<string, number> = {};
+	for (const c of changes) {
+		if (checkedIndices.has(changes.indexOf(c))) {
+			fieldCounts[c.lane] = (fieldCounts[c.lane] || 0) + 1;
+		}
+	}
+	const fieldSummary = Object.entries(fieldCounts)
+		.map(([field, count]) => `${count} ${field}`)
+		.join(", ");
+
+	const handleToggle = useCallback((i: number) => () => onToggle(i), [onToggle]);
+
+	return (
+		<div style={styles.container}>
+			<div style={styles.header}>
+				<span style={styles.summary}>
+					{checkedIndices.size} of {changes.length} changes selected
+					{fieldSummary && ` (${fieldSummary})`}
+				</span>
+
+				<span style={errorCount > 0 ? styles.validationError : styles.validationOk}>
+					{errorCount > 0
+						? `${errorCount} validation error${errorCount !== 1 ? "s" : ""}`
+						: "Validation passed"}
+				</span>
+			</div>
+
+			{!playbackAvailable && (
+				<div style={styles.playbackNotice}>
+					Edited without audio playback — reviewers will note this in the PR.
+				</div>
+			)}
+
+			<div style={styles.changeList}>
+				{changes.map((change, i) => (
+					<label key={`${change.lane}-${change.action.type}-${i}`} style={styles.changeRow}>
+						<input
+							type="checkbox"
+							checked={checkedIndices.has(i)}
+							onChange={handleToggle(i)}
+							style={styles.checkbox}
+						/>
+						<span style={styles.changeText}>{change.description}</span>
+					</label>
+				))}
+			</div>
+
+			{changes.length === 0 && <div style={styles.empty}>No changes to review.</div>}
+		</div>
+	);
+}
+
+const styles: Record<string, CSSProperties> = {
+	container: {
+		display: "flex",
+		flexDirection: "column",
+		gap: 12,
+	},
+	header: {
+		display: "flex",
+		justifyContent: "space-between",
+		alignItems: "center",
+		flexWrap: "wrap",
+		gap: 8,
+	},
+	summary: {
+		fontSize: 13,
+		color: "#8b949e",
+	},
+	validationOk: {
+		fontSize: 12,
+		color: "#3fb950",
+		fontWeight: 600,
+	},
+	validationError: {
+		fontSize: 12,
+		color: "#ff4444",
+		fontWeight: 600,
+	},
+	playbackNotice: {
+		padding: "8px 12px",
+		background: "#2d2a00",
+		border: "1px solid #5a5300",
+		borderRadius: 4,
+		fontSize: 13,
+		color: "#e3b341",
+	},
+	changeList: {
+		display: "flex",
+		flexDirection: "column",
+		gap: 4,
+		maxHeight: 300,
+		overflowY: "auto",
+	},
+	changeRow: {
+		display: "flex",
+		alignItems: "flex-start",
+		gap: 8,
+		padding: "4px 8px",
+		borderRadius: 3,
+		cursor: "pointer",
+		fontSize: 13,
+		color: "#c9d1d9",
+		background: "#161b22",
+	},
+	checkbox: {
+		marginTop: 2,
+		flexShrink: 0,
+	},
+	changeText: {
+		fontFamily: "monospace",
+		fontSize: 12,
+		lineHeight: "1.4",
+		wordBreak: "break-all",
+	},
+	empty: {
+		color: "#484f58",
+		fontSize: 13,
+		fontStyle: "italic",
+	},
+};

--- a/editor/src/components/GitHubAuth.tsx
+++ b/editor/src/components/GitHubAuth.tsx
@@ -1,0 +1,98 @@
+import { type CSSProperties, useCallback, useEffect, useState } from "react";
+import { clearToken, getStoredToken, initiateOAuth, validateToken } from "../github/auth";
+
+interface GitHubAuthProps {
+	onAuthChange: (token: string | null, login: string | null) => void;
+}
+
+export function GitHubAuth({ onAuthChange }: GitHubAuthProps) {
+	const [login, setLogin] = useState<string | null>(null);
+	const [checking, setChecking] = useState(true);
+
+	// Validate stored token on mount
+	useEffect(() => {
+		const token = getStoredToken();
+		if (!token) {
+			setChecking(false);
+			onAuthChange(null, null);
+			return;
+		}
+
+		validateToken(token).then((user) => {
+			if (user) {
+				setLogin(user.login);
+				onAuthChange(token, user.login);
+			} else {
+				// Token expired or revoked
+				clearToken();
+				onAuthChange(null, null);
+			}
+			setChecking(false);
+		});
+	}, [onAuthChange]);
+
+	const handleSignIn = useCallback(() => {
+		initiateOAuth();
+	}, []);
+
+	const handleSignOut = useCallback(() => {
+		clearToken();
+		setLogin(null);
+		onAuthChange(null, null);
+	}, [onAuthChange]);
+
+	if (checking) {
+		return <span style={styles.checking}>...</span>;
+	}
+
+	if (login) {
+		return (
+			<span style={styles.wrapper}>
+				<span style={styles.username}>@{login}</span>
+				<button type="button" onClick={handleSignOut} style={styles.signOut}>
+					Sign out
+				</button>
+			</span>
+		);
+	}
+
+	return (
+		<button type="button" onClick={handleSignIn} style={styles.signIn}>
+			Sign in with GitHub
+		</button>
+	);
+}
+
+const styles: Record<string, CSSProperties> = {
+	wrapper: {
+		display: "inline-flex",
+		alignItems: "center",
+		gap: 6,
+	},
+	checking: {
+		fontSize: 12,
+		color: "#666",
+	},
+	username: {
+		fontSize: 12,
+		color: "#8b949e",
+	},
+	signIn: {
+		padding: "4px 10px",
+		background: "#21262d",
+		border: "1px solid #363b42",
+		borderRadius: 4,
+		color: "#c9d1d9",
+		fontSize: 12,
+		cursor: "pointer",
+	},
+	signOut: {
+		padding: "2px 6px",
+		background: "transparent",
+		border: "1px solid #363b42",
+		borderRadius: 3,
+		color: "#8b949e",
+		fontSize: 11,
+		cursor: "pointer",
+	},
+};

--- a/editor/src/components/ProgressIndicator.tsx
+++ b/editor/src/components/ProgressIndicator.tsx
@@ -1,0 +1,117 @@
+import type { CSSProperties } from "react";
+import type { SubmitStep } from "../github/api";
+
+interface ProgressIndicatorProps {
+	currentStep: SubmitStep;
+	prUrl?: string;
+	error?: string;
+}
+
+const STEPS: { key: SubmitStep; label: string }[] = [
+	{ key: "forking", label: "Forking repository..." },
+	{ key: "branching", label: "Creating branch..." },
+	{ key: "committing", label: "Committing changes..." },
+	{ key: "opening-pr", label: "Opening pull request..." },
+	{ key: "done", label: "Done!" },
+];
+
+function stepIndex(step: SubmitStep): number {
+	return STEPS.findIndex((s) => s.key === step);
+}
+
+export function ProgressIndicator({ currentStep, prUrl, error }: ProgressIndicatorProps) {
+	const current = stepIndex(currentStep);
+
+	return (
+		<div style={styles.container}>
+			{STEPS.map((step, i) => {
+				let status: "pending" | "active" | "done";
+				if (i < current) status = "done";
+				else if (i === current) status = "active";
+				else status = "pending";
+
+				return (
+					<div key={step.key} style={styles.step}>
+						<span
+							style={{
+								...styles.dot,
+								...(status === "done"
+									? styles.dotDone
+									: status === "active"
+										? styles.dotActive
+										: styles.dotPending),
+							}}
+						/>
+						<span
+							style={{
+								...styles.label,
+								...(status === "pending" ? styles.labelPending : {}),
+							}}
+						>
+							{step.key === "done" && prUrl ? (
+								<a href={prUrl} target="_blank" rel="noopener noreferrer" style={styles.link}>
+									Done — view pull request
+								</a>
+							) : (
+								step.label
+							)}
+						</span>
+					</div>
+				);
+			})}
+
+			{error && <div style={styles.error}>{error}</div>}
+		</div>
+	);
+}
+
+const styles: Record<string, CSSProperties> = {
+	container: {
+		display: "flex",
+		flexDirection: "column",
+		gap: 10,
+		padding: "16px 0",
+	},
+	step: {
+		display: "flex",
+		alignItems: "center",
+		gap: 10,
+	},
+	dot: {
+		display: "inline-block",
+		width: 10,
+		height: 10,
+		borderRadius: "50%",
+		flexShrink: 0,
+	},
+	dotDone: {
+		background: "#3fb950",
+	},
+	dotActive: {
+		background: "#58a6ff",
+		boxShadow: "0 0 6px #58a6ff",
+	},
+	dotPending: {
+		background: "#30363d",
+	},
+	label: {
+		fontSize: 14,
+		color: "#c9d1d9",
+	},
+	labelPending: {
+		color: "#484f58",
+	},
+	link: {
+		color: "#58a6ff",
+		textDecoration: "none",
+	},
+	error: {
+		marginTop: 8,
+		padding: "8px 12px",
+		background: "#3a1a1a",
+		border: "1px solid #662222",
+		borderRadius: 4,
+		color: "#ff6666",
+		fontSize: 13,
+	},
+};

--- a/editor/src/components/SubmitFlow.tsx
+++ b/editor/src/components/SubmitFlow.tsx
@@ -1,0 +1,231 @@
+import type { PulseMap } from "pulsemap/schema";
+import { type CSSProperties, useCallback, useMemo, useState } from "react";
+import type { SubmitStep } from "../github/api";
+import { submitCorrection } from "../github/api";
+import { generateDiffSummary } from "../github/diff";
+import type { EditAction } from "../state/types";
+import { DiffReview } from "./DiffReview";
+import { ProgressIndicator } from "./ProgressIndicator";
+
+type FlowStep = "review" | "submitting" | "done" | "error";
+
+interface SubmitFlowProps {
+	map: PulseMap;
+	history: EditAction[];
+	token: string;
+	playbackAvailable: boolean;
+	errorCount: number;
+	onClose: () => void;
+}
+
+export function SubmitFlow({
+	map,
+	history,
+	token,
+	playbackAvailable,
+	errorCount,
+	onClose,
+}: SubmitFlowProps) {
+	const [flowStep, setFlowStep] = useState<FlowStep>("review");
+	const [submitStep, setSubmitStep] = useState<SubmitStep>("forking");
+	const [prUrl, setPrUrl] = useState<string | undefined>();
+	const [submitError, setSubmitError] = useState<string | undefined>();
+
+	// All changes checked by default
+	const diffResult = useMemo(() => generateDiffSummary(history), [history]);
+	const [checkedIndices, setCheckedIndices] = useState<Set<number>>(
+		() => new Set(diffResult.changes.map((_, i) => i)),
+	);
+
+	const handleToggle = useCallback((index: number) => {
+		setCheckedIndices((prev) => {
+			const next = new Set(prev);
+			if (next.has(index)) next.delete(index);
+			else next.add(index);
+			return next;
+		});
+	}, []);
+
+	// Filter history to only checked changes
+	const selectedHistory = useMemo(
+		() => history.filter((_, i) => checkedIndices.has(i)),
+		[history, checkedIndices],
+	);
+
+	const canSubmit = errorCount === 0 && selectedHistory.length > 0 && flowStep === "review";
+
+	const handleSubmit = useCallback(async () => {
+		setFlowStep("submitting");
+		setSubmitError(undefined);
+
+		try {
+			const result = await submitCorrection(
+				{
+					token,
+					mapId: map.id,
+					map,
+					history: selectedHistory,
+					playbackAvailable,
+					source: "PulseMap Editor",
+				},
+				(step) => setSubmitStep(step),
+			);
+			setPrUrl(result.prUrl);
+			setFlowStep("done");
+		} catch (err) {
+			setSubmitError(err instanceof Error ? err.message : "Submission failed");
+			setFlowStep("error");
+		}
+	}, [token, map, selectedHistory, playbackAvailable]);
+
+	return (
+		// biome-ignore lint/a11y/useKeyWithClickEvents: overlay dismiss is supplementary — close button handles keyboard
+		<div style={styles.overlay} onClick={onClose}>
+			{/* biome-ignore lint/a11y/useKeyWithClickEvents: stopPropagation prevents overlay dismiss when clicking modal */}
+			<div style={styles.modal} onClick={(e) => e.stopPropagation()}>
+				<div style={styles.header}>
+					<h2 style={styles.title}>Submit Correction</h2>
+					<button type="button" onClick={onClose} style={styles.close}>
+						x
+					</button>
+				</div>
+
+				<div style={styles.body}>
+					{(flowStep === "review" || flowStep === "error") && (
+						<>
+							<DiffReview
+								changes={diffResult.changes}
+								checkedIndices={checkedIndices}
+								onToggle={handleToggle}
+								playbackAvailable={playbackAvailable}
+								errorCount={errorCount}
+							/>
+
+							{submitError && <div style={styles.errorBox}>{submitError}</div>}
+
+							<div style={styles.actions}>
+								<button type="button" onClick={onClose} style={styles.cancelButton}>
+									Cancel
+								</button>
+								<button
+									type="button"
+									onClick={handleSubmit}
+									disabled={!canSubmit}
+									style={{
+										...styles.submitButton,
+										...(canSubmit ? {} : styles.submitButtonDisabled),
+									}}
+								>
+									Create Pull Request
+								</button>
+							</div>
+						</>
+					)}
+
+					{(flowStep === "submitting" || flowStep === "done") && (
+						<>
+							<ProgressIndicator currentStep={submitStep} prUrl={prUrl} error={submitError} />
+
+							{flowStep === "done" && (
+								<div style={styles.actions}>
+									<button type="button" onClick={onClose} style={styles.cancelButton}>
+										Close
+									</button>
+								</div>
+							)}
+						</>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+const styles: Record<string, CSSProperties> = {
+	overlay: {
+		position: "fixed",
+		inset: 0,
+		background: "rgba(0, 0, 0, 0.7)",
+		display: "flex",
+		alignItems: "center",
+		justifyContent: "center",
+		zIndex: 1000,
+	},
+	modal: {
+		background: "#0d1117",
+		border: "1px solid #30363d",
+		borderRadius: 8,
+		width: "90%",
+		maxWidth: 640,
+		maxHeight: "80vh",
+		display: "flex",
+		flexDirection: "column",
+		overflow: "hidden",
+	},
+	header: {
+		display: "flex",
+		justifyContent: "space-between",
+		alignItems: "center",
+		padding: "16px 20px",
+		borderBottom: "1px solid #21262d",
+	},
+	title: {
+		margin: 0,
+		fontSize: 16,
+		fontWeight: 600,
+		color: "#c9d1d9",
+	},
+	close: {
+		background: "transparent",
+		border: "none",
+		color: "#8b949e",
+		fontSize: 18,
+		cursor: "pointer",
+		padding: "4px 8px",
+		lineHeight: 1,
+	},
+	body: {
+		padding: "16px 20px",
+		overflowY: "auto",
+		display: "flex",
+		flexDirection: "column",
+		gap: 16,
+	},
+	errorBox: {
+		padding: "8px 12px",
+		background: "#3a1a1a",
+		border: "1px solid #662222",
+		borderRadius: 4,
+		color: "#ff6666",
+		fontSize: 13,
+	},
+	actions: {
+		display: "flex",
+		justifyContent: "flex-end",
+		gap: 8,
+		paddingTop: 8,
+	},
+	cancelButton: {
+		padding: "6px 14px",
+		background: "#21262d",
+		border: "1px solid #363b42",
+		borderRadius: 6,
+		color: "#c9d1d9",
+		fontSize: 13,
+		cursor: "pointer",
+	},
+	submitButton: {
+		padding: "6px 14px",
+		background: "#238636",
+		border: "1px solid #2ea043",
+		borderRadius: 6,
+		color: "#fff",
+		fontSize: 13,
+		fontWeight: 600,
+		cursor: "pointer",
+	},
+	submitButtonDisabled: {
+		opacity: 0.5,
+		cursor: "not-allowed",
+	},
+};

--- a/editor/src/components/Timeline.tsx
+++ b/editor/src/components/Timeline.tsx
@@ -15,6 +15,8 @@ import { WordLane } from "./lanes/WordLane";
 import { SectionLane } from "./lanes/SectionLane";
 import { DirtyIndicator } from "./DirtyIndicator";
 import { ExportButton } from "./ExportButton";
+import { GitHubAuth } from "./GitHubAuth";
+import { SubmitFlow } from "./SubmitFlow";
 import { ValidationPanel } from "./ValidationPanel";
 import { validateMap } from "../validation/validate";
 import type { ValidationIssue } from "../validation/types";
@@ -25,6 +27,10 @@ interface TimelineProps {
   position: number;
   playing: boolean;
   onSeek: (ms: number) => void;
+  ghToken: string | null;
+  ghLogin: string | null;
+  onAuthChange: (token: string | null, login: string | null) => void;
+  playbackAvailable: boolean;
 }
 
 function hasLaneData(map: PulseMap, lane: LaneName): boolean {
@@ -42,9 +48,20 @@ function hasLaneData(map: PulseMap, lane: LaneName): boolean {
   }
 }
 
-export function Timeline({ map, position, playing, onSeek }: TimelineProps) {
+export function Timeline({
+  map,
+  position,
+  playing,
+  onSeek,
+  ghToken,
+  ghLogin,
+  onAuthChange,
+  playbackAvailable,
+}: TimelineProps) {
   const { state, dispatch } = useEditor();
   const workingMap = state.working;
+
+  const [showSubmitFlow, setShowSubmitFlow] = useState(false);
 
   const [visibility, setVisibility] = useState<Record<LaneName, boolean>>({
     sections: true,
@@ -186,6 +203,21 @@ export function Timeline({ map, position, playing, onSeek }: TimelineProps) {
                 {errorCount} error{errorCount !== 1 ? "s" : ""} — fix before submitting
               </span>
             )}
+            <div style={styles.separator} />
+            <GitHubAuth onAuthChange={onAuthChange} />
+            {state.dirty && ghToken && (
+              <button
+                type="button"
+                onClick={() => setShowSubmitFlow(true)}
+                disabled={!canSubmit}
+                style={{
+                  ...styles.submitButton,
+                  ...(!canSubmit ? styles.submitButtonDisabled : {}),
+                }}
+              >
+                Submit Correction
+              </button>
+            )}
           </div>
           <div style={styles.toolbarRight}>
             {/* Snap controls */}
@@ -322,6 +354,17 @@ export function Timeline({ map, position, playing, onSeek }: TimelineProps) {
       {validationIssues.length > 0 && (
         <ValidationPanel issues={validationIssues} dispatch={dispatch} />
       )}
+
+      {showSubmitFlow && ghToken && (
+        <SubmitFlow
+          map={workingMap}
+          history={state.history}
+          token={ghToken}
+          playbackAvailable={playbackAvailable}
+          errorCount={errorCount}
+          onClose={() => setShowSubmitFlow(false)}
+        />
+      )}
     </div>
   );
 }
@@ -437,5 +480,19 @@ const styles: Record<string, CSSProperties> = {
   innerTrack: {
     position: "relative",
     minHeight: 40,
+  },
+  submitButton: {
+    padding: "4px 10px",
+    background: "#238636",
+    border: "1px solid #2ea043",
+    borderRadius: 4,
+    color: "#fff",
+    fontSize: 12,
+    fontWeight: 600,
+    cursor: "pointer",
+  },
+  submitButtonDisabled: {
+    opacity: 0.5,
+    cursor: "not-allowed",
   },
 };

--- a/editor/src/github/api.ts
+++ b/editor/src/github/api.ts
@@ -1,0 +1,200 @@
+/**
+ * GitHub API operations for submitting map corrections as pull requests.
+ *
+ * Flow: fork repo -> create branch -> commit map JSON -> open PR.
+ */
+import type { PulseMap } from "pulsemap/schema";
+import type { EditAction } from "../state/types";
+import { generateDiffSummary } from "./diff";
+
+const UPSTREAM_OWNER = "hartphoenix";
+const UPSTREAM_REPO = "pulsemap";
+const API_BASE = "https://api.github.com";
+
+interface SubmitCorrectionParams {
+	token: string;
+	mapId: string;
+	map: PulseMap;
+	history: EditAction[];
+	playbackAvailable: boolean;
+	source?: string;
+}
+
+interface SubmitCorrectionResult {
+	prUrl: string;
+	prNumber: number;
+}
+
+/** Callback for progress reporting during submission. */
+export type ProgressCallback = (step: SubmitStep) => void;
+
+export type SubmitStep = "forking" | "branching" | "committing" | "opening-pr" | "done";
+
+async function ghFetch(path: string, token: string, options: RequestInit = {}): Promise<Response> {
+	const url = path.startsWith("http") ? path : `${API_BASE}${path}`;
+	const res = await fetch(url, {
+		...options,
+		headers: {
+			Authorization: `token ${token}`,
+			Accept: "application/vnd.github.v3+json",
+			"Content-Type": "application/json",
+			...((options.headers as Record<string, string>) || {}),
+		},
+	});
+	return res;
+}
+
+async function ghJson<T>(path: string, token: string, options: RequestInit = {}): Promise<T> {
+	const res = await ghFetch(path, token, options);
+	if (!res.ok) {
+		const body = await res.text();
+		throw new Error(`GitHub API error ${res.status}: ${body}`);
+	}
+	return res.json() as Promise<T>;
+}
+
+function buildPrBody(params: {
+	map: PulseMap;
+	mapId: string;
+	history: EditAction[];
+	playbackAvailable: boolean;
+	source?: string;
+}): string {
+	const { map, mapId, history, playbackAvailable, source } = params;
+	const meta = map.metadata;
+	const title = meta?.title ?? mapId;
+	const artist = meta?.artist ?? "Unknown";
+	const { summary, changes, fieldCounts } = generateDiffSummary(history);
+
+	const changeLines = changes.map((c) => `- ${c.description}`).join("\n");
+
+	const playbackNote = !playbackAvailable
+		? "\n**Note:** Edited without audio playback available.\n"
+		: "";
+
+	const correctionMeta = JSON.stringify({
+		fields: fieldCounts,
+		playback_available: playbackAvailable,
+	});
+
+	return [
+		`## Map correction: "${title}" — ${artist}`,
+		`**Map ID:** \`${mapId}\``,
+		`**Submitted via:** ${source || "PulseMap Editor"}`,
+		playbackNote,
+		`### Changes (${history.length} edit${history.length !== 1 ? "s" : ""})`,
+		`${summary}`,
+		"",
+		changeLines,
+		"",
+		"<details><summary>Full edit history</summary>",
+		"",
+		"```json",
+		JSON.stringify(history, null, 2),
+		"```",
+		"",
+		"</details>",
+		"",
+		"<!-- pulsemap-correction",
+		correctionMeta,
+		"-->",
+	].join("\n");
+}
+
+export async function submitCorrection(
+	params: SubmitCorrectionParams,
+	onProgress?: ProgressCallback,
+): Promise<SubmitCorrectionResult> {
+	const { token, mapId, map, history, playbackAvailable, source } = params;
+
+	// 1. Get authenticated user
+	const user = await ghJson<{ login: string }>("/user", token);
+	const username = user.login;
+
+	// 2. Fork (idempotent — returns existing fork if already forked)
+	onProgress?.("forking");
+	await ghJson<{ full_name: string }>(`/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/forks`, token, {
+		method: "POST",
+		body: JSON.stringify({}),
+	});
+
+	// Brief pause to let GitHub propagate the fork
+	await new Promise((r) => setTimeout(r, 2000));
+
+	// 3. Get main branch SHA from the fork
+	onProgress?.("branching");
+	const mainRef = await ghJson<{ object: { sha: string } }>(
+		`/repos/${username}/${UPSTREAM_REPO}/git/ref/heads/main`,
+		token,
+	);
+	const mainSha = mainRef.object.sha;
+
+	// 4. Create branch
+	const timestamp = Date.now();
+	const branchName = `correction/${mapId}-${timestamp}`;
+	await ghJson<{ ref: string }>(`/repos/${username}/${UPSTREAM_REPO}/git/refs`, token, {
+		method: "POST",
+		body: JSON.stringify({
+			ref: `refs/heads/${branchName}`,
+			sha: mainSha,
+		}),
+	});
+
+	// 5. Get existing file SHA (for the update)
+	onProgress?.("committing");
+	const filePath = `maps/${mapId}.json`;
+	let fileSha: string | undefined;
+
+	try {
+		const existing = await ghJson<{ sha: string }>(
+			`/repos/${username}/${UPSTREAM_REPO}/contents/${filePath}?ref=main`,
+			token,
+		);
+		fileSha = existing.sha;
+	} catch {
+		// File doesn't exist yet — new map
+	}
+
+	// 6. Commit the map JSON
+	const content = btoa(unescape(encodeURIComponent(JSON.stringify(map, null, 2))));
+	await ghJson<{ commit: { sha: string } }>(
+		`/repos/${username}/${UPSTREAM_REPO}/contents/${filePath}`,
+		token,
+		{
+			method: "PUT",
+			body: JSON.stringify({
+				message: `fix(map): corrections for ${mapId}`,
+				content,
+				branch: branchName,
+				...(fileSha ? { sha: fileSha } : {}),
+			}),
+		},
+	);
+
+	// 7. Create PR against upstream
+	onProgress?.("opening-pr");
+	const prBody = buildPrBody({ map, mapId, history, playbackAvailable, source });
+	const meta = map.metadata;
+	const prTitle = `fix(map): ${meta?.title ?? mapId} corrections`;
+
+	const pr = await ghJson<{ html_url: string; number: number }>(
+		`/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/pulls`,
+		token,
+		{
+			method: "POST",
+			body: JSON.stringify({
+				title: prTitle,
+				body: prBody,
+				head: `${username}:${branchName}`,
+				base: "main",
+			}),
+		},
+	);
+
+	onProgress?.("done");
+
+	return {
+		prUrl: pr.html_url,
+		prNumber: pr.number,
+	};
+}

--- a/editor/src/github/auth.ts
+++ b/editor/src/github/auth.ts
@@ -1,0 +1,66 @@
+/**
+ * GitHub OAuth flow: redirect, token exchange, and token storage.
+ *
+ * CLIENT_ID and TOKEN_EXCHANGE_URL are placeholders — set them via
+ * environment config or replace before deploying.
+ */
+
+const CLIENT_ID = ""; // placeholder — set via environment or config
+const TOKEN_EXCHANGE_URL = ""; // placeholder — serverless function URL
+
+const TOKEN_KEY = "pulsemap-gh-token";
+
+/** Redirect the user to GitHub's OAuth authorize page. */
+export function initiateOAuth(): void {
+	const redirectUri = `${window.location.origin}/callback`;
+	const url = `https://github.com/login/oauth/authorize?client_id=${encodeURIComponent(CLIENT_ID)}&scope=public_repo&redirect_uri=${encodeURIComponent(redirectUri)}`;
+	window.location.href = url;
+}
+
+/** Exchange an OAuth code for an access token via the token exchange endpoint. */
+export async function handleCallback(code: string): Promise<string> {
+	const res = await fetch(TOKEN_EXCHANGE_URL, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ code }),
+	});
+
+	if (!res.ok) {
+		throw new Error(`Token exchange failed: ${res.status} ${res.statusText}`);
+	}
+
+	const data = (await res.json()) as { access_token?: string };
+	if (!data.access_token) {
+		throw new Error("Token exchange response missing access_token");
+	}
+	return data.access_token;
+}
+
+/** Read stored token from localStorage. */
+export function getStoredToken(): string | null {
+	return localStorage.getItem(TOKEN_KEY);
+}
+
+/** Persist a token to localStorage. */
+export function storeToken(token: string): void {
+	localStorage.setItem(TOKEN_KEY, token);
+}
+
+/** Remove the stored token. */
+export function clearToken(): void {
+	localStorage.removeItem(TOKEN_KEY);
+}
+
+/** Validate a token by calling GET /user. Returns user info or null if invalid. */
+export async function validateToken(token: string): Promise<{ login: string } | null> {
+	try {
+		const res = await fetch("https://api.github.com/user", {
+			headers: { Authorization: `token ${token}` },
+		});
+		if (!res.ok) return null;
+		const data = (await res.json()) as { login: string };
+		return data;
+	} catch {
+		return null;
+	}
+}

--- a/editor/src/github/diff.ts
+++ b/editor/src/github/diff.ts
@@ -1,0 +1,96 @@
+/**
+ * Generate human-readable diff summaries from EditAction[] history.
+ */
+import type { EditAction, EditableLane } from "../state/types";
+
+export interface DiffChange {
+	/** Human-readable description of the change */
+	description: string;
+	/** Which lane was affected */
+	lane: EditableLane;
+	/** The original EditAction */
+	action: EditAction;
+}
+
+export interface DiffSummary {
+	/** One-line summary like "3 chords modified, 2 sections added" */
+	summary: string;
+	/** Individual human-readable changes */
+	changes: DiffChange[];
+	/** Count of changes per field, for pulsemap-correction metadata */
+	fieldCounts: Record<string, number>;
+}
+
+function formatMs(ms: number): string {
+	return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function describeAction(action: EditAction): string {
+	switch (action.type) {
+		case "move":
+			return (
+				`${action.lane}[${action.index}]: ` +
+				`Repositioned ${formatMs(action.before.t)} -> ${formatMs(action.after.t)}`
+			);
+		case "resize":
+			return (
+				`${action.lane}[${action.index}]: ` +
+				`End changed ${action.before.end != null ? `${action.before.end}ms` : "none"} -> ` +
+				`${action.after.end != null ? `${action.after.end}ms` : "none"}`
+			);
+		case "edit-text":
+			return (
+				`${action.lane}[${action.index}]: ` +
+				`Changed "${action.before}" -> "${action.after}" at ${action.field}`
+			);
+		case "edit-field":
+			return (
+				`${action.lane}[${action.index}]: ` +
+				`${action.field} changed from ${JSON.stringify(action.before)} ` +
+				`to ${JSON.stringify(action.after)}`
+			);
+		case "insert":
+			return `${action.lane}: Added ${describeInsertedValue(action)} at index ${action.index}`;
+		case "delete":
+			return `${action.lane}[${action.index}]: Deleted ${describeDeletedValue(action)}`;
+	}
+}
+
+function describeInsertedValue(action: EditAction & { type: "insert" }): string {
+	const val = action.value as Record<string, unknown>;
+	if (action.lane === "chords" && val.chord) return `"${val.chord}"`;
+	if (action.lane === "sections" && val.label) return `"${val.label}"`;
+	if ((action.lane === "words" || action.lane === "lyrics") && val.text) return `"${val.text}"`;
+	return "item";
+}
+
+function describeDeletedValue(action: EditAction & { type: "delete" }): string {
+	const val = action.value as Record<string, unknown>;
+	if (action.lane === "chords" && val.chord) return `"${val.chord}"`;
+	if (action.lane === "sections" && val.label) return `"${val.label}"`;
+	if ((action.lane === "words" || action.lane === "lyrics") && val.text) return `"${val.text}"`;
+	return "item";
+}
+
+export function generateDiffSummary(history: EditAction[]): DiffSummary {
+	const changes: DiffChange[] = history.map((action) => ({
+		description: describeAction(action),
+		lane: action.lane,
+		action,
+	}));
+
+	// Count changes per lane
+	const fieldCounts: Record<string, number> = {};
+	for (const action of history) {
+		fieldCounts[action.lane] = (fieldCounts[action.lane] || 0) + 1;
+	}
+
+	// Build summary string
+	const parts: string[] = [];
+	for (const [field, count] of Object.entries(fieldCounts)) {
+		parts.push(`${count} ${field}`);
+	}
+	const summary = parts.length > 0 ? parts.join(", ") : "no changes";
+
+	return { summary, changes, fieldCounts };
+}


### PR DESCRIPTION
## Summary
- Add GitHub OAuth authentication (redirect flow, localStorage token persistence, token validation)
- Add multi-step PR submission modal: review edits with per-change checkboxes, confirm, track progress, link to created PR
- Generate human-readable diff summaries from EditAction[] history for PR bodies
- PR body includes machine-readable `<!-- pulsemap-correction -->` metadata block for the GitHub Action parser
- Toolbar shows sign-in/out state and "Submit Correction" button (gated on auth + validation + dirty state)

## New files
- `editor/src/github/auth.ts` — OAuth redirect, token exchange, token storage
- `editor/src/github/api.ts` — fork, branch, commit, PR via GitHub API
- `editor/src/github/diff.ts` — human-readable diff from EditAction[] history
- `editor/src/components/GitHubAuth.tsx` — sign in/out UI
- `editor/src/components/SubmitFlow.tsx` — multi-step submission modal
- `editor/src/components/DiffReview.tsx` — change review with per-change checkboxes
- `editor/src/components/ProgressIndicator.tsx` — step-by-step progress display

## Notes
- `CLIENT_ID` and `TOKEN_EXCHANGE_URL` in `auth.ts` are placeholders — need a GitHub OAuth app and serverless token exchange function before this is functional
- Passes `tsc --noEmit` and `biome check` cleanly

## Test plan
- [ ] Verify typecheck passes: `cd editor && bun run typecheck`
- [ ] Verify lint passes: `bun run lint` (from repo root)
- [ ] Manual: load editor, confirm "Sign in with GitHub" appears in toolbar
- [ ] Manual: with dirty state + auth, confirm "Submit Correction" button appears
- [ ] Manual: open submit modal, verify diff review shows edit history with checkboxes
- [ ] End-to-end: configure OAuth app + token exchange, test full flow through PR creation

Generated with [Claude Code](https://claude.com/claude-code)