### PR TITLE
fix(editor): switch to GitHub device flow auth, set CLIENT_ID

### DIFF
--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -2,7 +2,7 @@ import type { PulseMap } from "pulsemap/schema";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Timeline } from "./components/Timeline";
 import { TransportBar } from "./components/TransportBar";
-import { getStoredToken, handleCallback, storeToken, validateToken } from "./github/auth";
+import { getStoredToken, storeToken, validateToken } from "./github/auth";
 import { useBeatSnap } from "./hooks/useBeatSnap";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useMap } from "./hooks/useMap";
@@ -207,40 +207,7 @@ export function App() {
 	// --- GitHub OAuth state ---
 	const [ghToken, setGhToken] = useState<string | null>(null);
 	const [ghLogin, setGhLogin] = useState<string | null>(null);
-	const callbackHandled = useRef(false);
-
-	// Handle OAuth callback: ?code=... in the URL
-	useEffect(() => {
-		if (callbackHandled.current) return;
-		const urlParams = new URLSearchParams(window.location.search);
-		const code = urlParams.get("code");
-		if (!code) return;
-
-		callbackHandled.current = true;
-
-		handleCallback(code)
-			.then((token) => {
-				storeToken(token);
-				setGhToken(token);
-				return validateToken(token);
-			})
-			.then((user) => {
-				if (user) setGhLogin(user.login);
-				// Clean the URL — remove code param
-				const clean = new URL(window.location.href);
-				clean.searchParams.delete("code");
-				window.history.replaceState({}, "", clean.toString());
-			})
-			.catch((err) => {
-				console.error("OAuth callback failed:", err);
-				// Clean the URL anyway
-				const clean = new URL(window.location.href);
-				clean.searchParams.delete("code");
-				window.history.replaceState({}, "", clean.toString());
-			});
-	}, []);
-
-	// Initialize from stored token (no callback)
+	// Initialize from stored token
 	const tokenInitialized = useRef(false);
 	useEffect(() => {
 		if (tokenInitialized.current) return;

--- a/editor/src/components/GitHubAuth.tsx
+++ b/editor/src/components/GitHubAuth.tsx
@@ -1,5 +1,13 @@
 import { type CSSProperties, useCallback, useEffect, useState } from "react";
-import { clearToken, getStoredToken, initiateOAuth, validateToken } from "../github/auth";
+import {
+	type DeviceCodeResponse,
+	clearToken,
+	getStoredToken,
+	pollForToken,
+	requestDeviceCode,
+	storeToken,
+	validateToken,
+} from "../github/auth";
 
 interface GitHubAuthProps {
 	onAuthChange: (token: string | null, login: string | null) => void;
@@ -8,8 +16,9 @@ interface GitHubAuthProps {
 export function GitHubAuth({ onAuthChange }: GitHubAuthProps) {
 	const [login, setLogin] = useState<string | null>(null);
 	const [checking, setChecking] = useState(true);
+	const [deviceFlow, setDeviceFlow] = useState<DeviceCodeResponse | null>(null);
+	const [error, setError] = useState<string | null>(null);
 
-	// Validate stored token on mount
 	useEffect(() => {
 		const token = getStoredToken();
 		if (!token) {
@@ -23,7 +32,6 @@ export function GitHubAuth({ onAuthChange }: GitHubAuthProps) {
 				setLogin(user.login);
 				onAuthChange(token, user.login);
 			} else {
-				// Token expired or revoked
 				clearToken();
 				onAuthChange(null, null);
 			}
@@ -31,9 +39,26 @@ export function GitHubAuth({ onAuthChange }: GitHubAuthProps) {
 		});
 	}, [onAuthChange]);
 
-	const handleSignIn = useCallback(() => {
-		initiateOAuth();
-	}, []);
+	const handleSignIn = useCallback(async () => {
+		setError(null);
+		try {
+			const device = await requestDeviceCode();
+			setDeviceFlow(device);
+
+			const token = await pollForToken(device.device_code, device.interval);
+			storeToken(token);
+			setDeviceFlow(null);
+
+			const user = await validateToken(token);
+			if (user) {
+				setLogin(user.login);
+				onAuthChange(token, user.login);
+			}
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Auth failed");
+			setDeviceFlow(null);
+		}
+	}, [onAuthChange]);
 
 	const handleSignOut = useCallback(() => {
 		clearToken();
@@ -56,10 +81,30 @@ export function GitHubAuth({ onAuthChange }: GitHubAuthProps) {
 		);
 	}
 
+	if (deviceFlow) {
+		return (
+			<span style={styles.deviceFlow}>
+				<span style={styles.deviceLabel}>Enter code at</span>
+				<a
+					href={deviceFlow.verification_uri}
+					target="_blank"
+					rel="noopener noreferrer"
+					style={styles.deviceLink}
+				>
+					{deviceFlow.verification_uri}
+				</a>
+				<code style={styles.deviceCode}>{deviceFlow.user_code}</code>
+			</span>
+		);
+	}
+
 	return (
-		<button type="button" onClick={handleSignIn} style={styles.signIn}>
-			Sign in with GitHub
-		</button>
+		<span style={styles.wrapper}>
+			<button type="button" onClick={handleSignIn} style={styles.signIn}>
+				Sign in with GitHub
+			</button>
+			{error && <span style={styles.error}>{error}</span>}
+		</span>
 	);
 }
 
@@ -94,5 +139,32 @@ const styles: Record<string, CSSProperties> = {
 		color: "#8b949e",
 		fontSize: 11,
 		cursor: "pointer",
+	},
+	deviceFlow: {
+		display: "inline-flex",
+		alignItems: "center",
+		gap: 8,
+		fontSize: 12,
+	},
+	deviceLabel: {
+		color: "#8b949e",
+	},
+	deviceLink: {
+		color: "#58a6ff",
+		textDecoration: "none",
+	},
+	deviceCode: {
+		padding: "2px 8px",
+		background: "#21262d",
+		border: "1px solid #363b42",
+		borderRadius: 4,
+		color: "#ffd93d",
+		fontSize: 14,
+		fontWeight: 600,
+		letterSpacing: 2,
+	},
+	error: {
+		color: "#f85149",
+		fontSize: 11,
 	},
 };

--- a/editor/src/github/auth.ts
+++ b/editor/src/github/auth.ts
@@ -1,39 +1,93 @@
 /**
- * GitHub OAuth flow: redirect, token exchange, and token storage.
+ * GitHub OAuth device flow: no server-side token exchange needed.
  *
- * CLIENT_ID and TOKEN_EXCHANGE_URL are placeholders — set them via
- * environment config or replace before deploying.
+ * Flow:
+ * 1. POST /login/device/code → get device_code, user_code, verification_uri
+ * 2. Show user the code and link
+ * 3. Poll /login/oauth/access_token until user authorizes
  */
 
-const CLIENT_ID = ""; // placeholder — set via environment or config
-const TOKEN_EXCHANGE_URL = ""; // placeholder — serverless function URL
+const CLIENT_ID = "Ov23li12vkglROrSw2N1";
 
 const TOKEN_KEY = "pulsemap-gh-token";
 
-/** Redirect the user to GitHub's OAuth authorize page. */
-export function initiateOAuth(): void {
-	const redirectUri = `${window.location.origin}/callback`;
-	const url = `https://github.com/login/oauth/authorize?client_id=${encodeURIComponent(CLIENT_ID)}&scope=public_repo&redirect_uri=${encodeURIComponent(redirectUri)}`;
-	window.location.href = url;
+export interface DeviceCodeResponse {
+	device_code: string;
+	user_code: string;
+	verification_uri: string;
+	expires_in: number;
+	interval: number;
 }
 
-/** Exchange an OAuth code for an access token via the token exchange endpoint. */
-export async function handleCallback(code: string): Promise<string> {
-	const res = await fetch(TOKEN_EXCHANGE_URL, {
+/** Request a device code from GitHub. */
+export async function requestDeviceCode(): Promise<DeviceCodeResponse> {
+	const res = await fetch("https://github.com/login/device/code", {
 		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ code }),
+		headers: {
+			Accept: "application/json",
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			client_id: CLIENT_ID,
+			scope: "public_repo",
+		}),
 	});
 
 	if (!res.ok) {
-		throw new Error(`Token exchange failed: ${res.status} ${res.statusText}`);
+		throw new Error(`Device code request failed: ${res.status}`);
 	}
 
-	const data = (await res.json()) as { access_token?: string };
-	if (!data.access_token) {
-		throw new Error("Token exchange response missing access_token");
+	return (await res.json()) as DeviceCodeResponse;
+}
+
+/**
+ * Poll for the access token after user enters the device code.
+ * Resolves with the token when authorized, rejects on expiry or denial.
+ */
+export async function pollForToken(deviceCode: string, interval: number): Promise<string> {
+	const pollInterval = Math.max(interval, 5) * 1000;
+
+	while (true) {
+		await new Promise((r) => setTimeout(r, pollInterval));
+
+		const res = await fetch("https://github.com/login/oauth/access_token", {
+			method: "POST",
+			headers: {
+				Accept: "application/json",
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				client_id: CLIENT_ID,
+				device_code: deviceCode,
+				grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+			}),
+		});
+
+		if (!res.ok) continue;
+
+		const data = (await res.json()) as {
+			access_token?: string;
+			error?: string;
+		};
+
+		if (data.access_token) {
+			return data.access_token;
+		}
+
+		if (data.error === "authorization_pending") continue;
+		if (data.error === "slow_down") {
+			await new Promise((r) => setTimeout(r, 5000));
+			continue;
+		}
+		if (data.error === "expired_token") {
+			throw new Error("Device code expired. Please try again.");
+		}
+		if (data.error === "access_denied") {
+			throw new Error("Authorization denied by user.");
+		}
+
+		throw new Error(`Unexpected error: ${data.error}`);
 	}
-	return data.access_token;
 }
 
 /** Read stored token from localStorage. */


### PR DESCRIPTION
## Summary
- Replace redirect-based OAuth with device flow (no server-side token exchange needed)
- Set CLIENT_ID to registered app value
- User clicks "Sign in" → gets a code + link → enters code on GitHub → app polls for token
- Remove OAuth callback handling from App.tsx