### PR TITLE
fix(editor): deploy editor to GitHub Pages and fix deep link routing

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -26,12 +26,43 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Build editor
+        working-directory: editor
+        run: |
+          bun install --frozen-lockfile
+          bun run build
+
       - name: Build site directory
         run: |
-          mkdir -p _site/maps/midi
+          mkdir -p _site/maps/midi _site/editor
           cp maps/*.json _site/maps/ 2>/dev/null || true
           cp maps/midi/*.mid _site/maps/midi/ 2>/dev/null || true
+          cp -r editor/dist/* _site/editor/
           touch _site/.nojekyll
+
+          # SPA fallback: GitHub Pages serves 404.html at the site root
+          # for any unknown path. Redirect /pulsemap/editor/* deep links
+          # back to the editor's index.html preserving path and query.
+          cat > _site/404.html << 'FALLBACK'
+          <!DOCTYPE html>
+          <html>
+          <head><meta charset="utf-8">
+          <script>
+            var p = window.location.pathname;
+            if (p.startsWith('/pulsemap/editor/')) {
+              var s = window.location.search;
+              var sep = s ? s + '&' : '?';
+              window.location.replace('/pulsemap/editor/' + sep + 'route=' + encodeURIComponent(p));
+            }
+          </script>
+          </head>
+          <body></body>
+          </html>
+          FALLBACK
 
           # Generate manifest of all maps
           node -e "

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -13,9 +13,16 @@ import { EditorProvider, useEditor } from "./state/context";
 import { parseEditorParams } from "./types";
 
 function getMapId(): string | null {
-	const path = window.location.pathname;
-	// Strip leading slash, return null if empty
-	const id = path.replace(/^\/+/, "");
+	const base = import.meta.env.BASE_URL ?? "/";
+	const params = new URLSearchParams(window.location.search);
+	const route = params.get("route");
+	const path = route ?? window.location.pathname;
+	const id = path.startsWith(base) ? path.slice(base.length) : path.replace(/^\/+/, "");
+	if (route && id) {
+		params.delete("route");
+		const qs = params.toString();
+		window.history.replaceState(null, "", `${base}${id}${qs ? `?${qs}` : ""}`);
+	}
 	return id || null;
 }
 

--- a/editor/vite.config.ts
+++ b/editor/vite.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 export default defineConfig({
+	base: "/pulsemap/editor/",
 	plugins: [react()],
 	resolve: {
 		alias: [


### PR DESCRIPTION
## Summary
- **Editor was never deployed** — the Pages workflow only copied map JSON/MIDI files. `openEditor()` from the SDK opened a URL that didn't exist.
- **`getMapId()` pathname bug** — even if deployed, the function stripped only leading slashes, so on Pages the mapId would be `pulsemap/editor/{id}` instead of just `{id}`.
- **No SPA fallback** — GitHub Pages returns 404 for deep links like `/pulsemap/editor/{mapId}`.

## Changes
- Add `oven-sh/setup-bun` + `bun run build` to `deploy-pages.yml`, copy `editor/dist/` into `_site/editor/`
- Set Vite `base: "/pulsemap/editor/"` for correct asset resolution under the Pages subdirectory
- Rewrite `getMapId()` to strip `import.meta.env.BASE_URL` prefix (works in both dev and production)
- Add root-level `404.html` SPA fallback that redirects `/pulsemap/editor/*` deep links back to the editor, preserving path and query params

## Test plan
- [ ] Merge and verify deploy workflow succeeds in Actions
- [ ] Visit `https://hartphoenix.github.io/pulsemap/editor/` — should show editor landing page
- [ ] Visit `https://hartphoenix.github.io/pulsemap/editor/{mapId}` — should load the map
- [ ] Deep link with params (`?t=5000&lane=chords`) — should preserve params after redirect
- [ ] Test `openEditor()` from PulseGuide — should open editor at correct position
- [ ] Verify `bun run dev` in editor still works (serves at `/pulsemap/editor/` locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)