### PR TITLE
fix(deploy): install root deps for editor build

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'maps/**'
       - 'editor/**'
+      - '.github/workflows/deploy-pages.yml'
 
   workflow_dispatch:
 
@@ -29,6 +30,9 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      - name: Install root dependencies
+        run: bun install --frozen-lockfile
 
       - name: Build editor
         working-directory: editor


### PR DESCRIPTION
## Summary
The deploy from #32 failed because the editor build couldn't resolve `@sinclair/typebox` — it's a root dependency that `schema/map.ts` imports, but the workflow only ran `bun install` inside `editor/`.

## Changes
- Add `bun install --frozen-lockfile` at repo root before the editor build step
- Add `.github/workflows/deploy-pages.yml` to the paths trigger so workflow-only changes redeploy

## Test plan
- [ ] Merge and verify deploy workflow succeeds
- [ ] Visit `https://hartphoenix.github.io/pulsemap/editor/` — editor loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)