### PR TITLE
feat(bootstrap): add --light mode and lyric offset correction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,8 +155,8 @@ own adapter contract. Community-contributed adapters accepted via PR.
 
 ### Bootstrap pipeline
 
-Generates maps from audio/video sources (~147s per song on Apple
-Silicon). Pipeline stages:
+Generates maps from audio/video sources (~147s per song full,
+~65s light mode on Apple Silicon). Pipeline stages:
 
 1. **Extract audio** (yt-dlp for URLs, direct for local files)
 2. **Fingerprint** (fpcalc / Chromaprint → MusicBrainz ID)
@@ -170,8 +170,10 @@ Silicon). Pipeline stages:
    - Lead → torchcrepe, backing → basic-pitch
 5. **Parallel analysis:**
    - Lyrics lookup (LRCLIB / YouTube VTT) → text cleanup →
-     LRCLIB offset correction (shift timestamps when >2s offset
-     detected) → word-level alignment (WhisperX on vocal stem) →
+     word-level alignment (WhisperX on vocal stem) →
+     lyric offset correction (sliding-window Jaccard text similarity
+     between LRCLIB lines and WhisperX clusters — detects and
+     corrects YouTube intro offset) →
      word reconciliation (Claude Haiku corrects WhisperX text
      against LRCLIB canonical lyrics)
    - Audio analysis (essentia → chords, beats, key, tempo)
@@ -202,6 +204,7 @@ Options:
 - `--limit N` — process at most N songs
 - `--log path` — results log path (default: `batch-results.json`)
 - `--concurrency N` — parallel pipelines (default: 1, GPU-bound)
+- `--light` — light mode (see below)
 
 The results log (`batch-results.json`) records every song's status,
 timing, error messages, and populated fields. Written after each
@@ -219,6 +222,41 @@ instrument learners (guitar, piano, ukulele, bass), spanning 1950s–
 "easy piano songs for adults", etc. YouTube URLs point to official
 channels where possible but **have not been individually verified** —
 videos may be taken down or replaced. Spot-check before bulk runs.
+
+### Light mode
+
+`--light` produces demo-ready maps (~65s/song) with lyrics,
+per-word timestamps, chords, and beats — skipping MIDI
+transcription, polyphony/vocal splitting, and Claude Haiku word
+reconciliation. Demucs still runs (vocal stem needed for WhisperX).
+
+```bash
+bun run bootstrap <source> --light           # Single song
+bun run batch songs.json --light --limit 10  # Batch
+```
+
+Skipped stages: polyphony detection, MelBand RoFormer lead/backing
+split, all 5 MIDI transcriptions, MIDI beat alignment,
+cross-validation, Haiku word reconciliation. Light-mode maps have
+`analysis.mode.tool === "light"` in provenance.
+
+### Lyric offset correction
+
+YouTube versions often have intro silence or different intros that
+shift all LRCLIB lyrics relative to the audio. The `lyric-offset`
+stage detects and corrects this using sliding-window Jaccard text
+similarity between LRCLIB line text and WhisperX word clusters.
+
+For each candidate offset (-120s to +120s, 500ms steps), it shifts
+LRCLIB lines and scores how well they text-match the nearest
+WhisperX cluster. Correction is applied when: the offset exceeds
+2s, avg similarity at the best offset is ≥25%, and improvement
+over offset=0 is ≥15 percentage points.
+
+Runs in both full and light mode. Does not handle cases where the
+YouTube version has fundamentally different content than LRCLIB
+(e.g., different edits, missing intros) — those need manual
+correction in the editor.
 
 ### Map Editor
 

--- a/src/bootstrap/batch.ts
+++ b/src/bootstrap/batch.ts
@@ -35,6 +35,7 @@ Options:
   --skip-existing        Skip songs that already have maps
   --start <n>            Start from song N (0-indexed, for resuming)
   --limit <n>            Process at most N songs
+  --light                Light mode: lyrics + words + chords + beats (no MIDI, polyphony split, or Haiku)
   --help                 Show this help message`);
 		process.exit(args.includes("--help") ? 0 : 1);
 	}
@@ -46,6 +47,8 @@ Options:
 	for (let i = 1; i < args.length; i++) {
 		if (args[i] === "--skip-existing") {
 			flags.add("skip-existing");
+		} else if (args[i] === "--light") {
+			flags.add("light");
 		} else if (args[i].startsWith("--") && args[i + 1]) {
 			opts[args[i].slice(2)] = args[i + 1];
 			i++;
@@ -110,7 +113,7 @@ Options:
 		console.log(`${label} START ${song.title} by ${song.artist}`);
 
 		try {
-			const map = await bootstrap(song.url, { outputDir });
+			const map = await bootstrap(song.url, { outputDir, light: flags.has("light") });
 
 			const duration_s = Math.round((performance.now() - songStart) / 1000);
 			const fields: string[] = [];

--- a/src/bootstrap/cli.ts
+++ b/src/bootstrap/cli.ts
@@ -13,6 +13,7 @@ Options:
   --output <path>        Output file path (default: maps/<id>.json)
   --acoustid-key <key>   AcoustID API key (or set ACOUSTID_API_KEY env var)
   --skip-separation      Skip Demucs source separation
+  --light                Light mode: lyrics + words + chords + beats (no MIDI, polyphony split, or Haiku)
   --help                 Show this help message`);
 		process.exit(args.includes("--help") ? 0 : 1);
 	}
@@ -24,6 +25,8 @@ Options:
 	for (let i = 1; i < args.length; i++) {
 		if (args[i] === "--skip-separation") {
 			flags.add("skip-separation");
+		} else if (args[i] === "--light") {
+			flags.add("light");
 		} else if (args[i].startsWith("--") && args[i + 1]) {
 			opts[args[i].slice(2)] = args[i + 1];
 			i++;
@@ -36,6 +39,7 @@ Options:
 			output: opts.output,
 			acoustIdKey: opts["acoustid-key"],
 			skipSeparation: flags.has("skip-separation"),
+			light: flags.has("light"),
 		});
 	} catch (err) {
 		console.error(err instanceof Error ? err.message : err);

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -25,6 +25,7 @@ import {
 import { reconcileWords } from "./stages/reconcile-words";
 import { type StemPaths, separateAudio, separateVocals } from "./stages/separate";
 import { type TranscriptionResult, transcribeStem } from "./stages/transcribe";
+import { detectLyricOffset } from "./stages/lyric-offset";
 import { alignWords } from "./stages/word-align";
 
 export interface BootstrapOptions {
@@ -33,6 +34,7 @@ export interface BootstrapOptions {
 	outputDir?: string;
 	acoustIdKey?: string;
 	skipSeparation?: boolean;
+	light?: boolean;
 }
 
 const SCHEMA_VERSION = "0.1.0";
@@ -41,6 +43,9 @@ export async function bootstrap(source: string, options: BootstrapOptions = {}):
 	const log = new PipelineLogger();
 	const workDir = join(process.env.TMPDIR || "/tmp", `pulsemap-${Date.now()}`);
 	await mkdir(workDir, { recursive: true });
+
+	const isLight = options.light ?? false;
+	if (isLight) log.info("Light mode: skipping MIDI, polyphony split, word reconciliation");
 
 	try {
 		// === Phase 1: Sequential setup ===
@@ -103,7 +108,7 @@ export async function bootstrap(source: string, options: BootstrapOptions = {}):
 		}
 
 		// === Phase 2.5: Vocal polyphony detection + lead isolation ===
-		if (stems?.vocals) {
+		if (stems?.vocals && !isLight) {
 			log.stage("polyphony-detect");
 			try {
 				const polyphonyResult = await detectPolyphony(stems.vocals);
@@ -239,28 +244,25 @@ export async function bootstrap(source: string, options: BootstrapOptions = {}):
 					log.stageSkip("word-align", "no vocal stem");
 				}
 
-				// Apply LRCLIB intro offset correction when validation failed and offset exceeds 2s
+				// Sliding-window lyric offset correction via text similarity
 				let correctedLyrics = cleanedLyrics;
-				if (
-					!lrclibValidated &&
-					lrclibOffsetMs != null &&
-					Math.abs(lrclibOffsetMs) > 2000 &&
-					cleanedLyrics?.length
-				) {
-					const offsetToApply = lrclibOffsetMs;
-					correctedLyrics = cleanedLyrics.map((line) => ({
-						...line,
-						t: Math.max(0, line.t - offsetToApply),
-						...(line.end != null ? { end: Math.max(0, line.end - offsetToApply) } : {}),
-					}));
-					log.detail(
-						`lrclib-offset: shifted ${cleanedLyrics.length} lyrics by ${(-offsetToApply / 1000).toFixed(1)}s`,
-					);
+				if (words?.length && cleanedLyrics?.length) {
+					log.stage("lyric-offset");
+					const offsetResult = detectLyricOffset(cleanedLyrics, words);
+					if (offsetResult.accepted) {
+						correctedLyrics = offsetResult.lyrics;
+						log.stageOk(
+							"lyric-offset",
+							`shifted ${cleanedLyrics.length} lyrics by ${(offsetResult.offsetMs / 1000).toFixed(1)}s (similarity: ${(offsetResult.avgSimilarity * 100).toFixed(0)}%, was ${(offsetResult.zeroSimilarity * 100).toFixed(0)}%)`,
+						);
+					} else {
+						log.stageOk("lyric-offset", `no correction needed (similarity: ${(offsetResult.zeroSimilarity * 100).toFixed(0)}%)`);
+					}
 				}
 
 				// Word reconciliation: correct WhisperX text against LRCLIB canonical lyrics
 				let wordsReconciled = false;
-				if (words?.length && correctedLyrics?.length) {
+				if (!isLight && words?.length && correctedLyrics?.length) {
 					try {
 						const reconciled = await reconcileWords(words, correctedLyrics, { title, artist });
 						if (reconciled.correctionCount > 0) {
@@ -339,6 +341,7 @@ export async function bootstrap(source: string, options: BootstrapOptions = {}):
 
 			// Bass MIDI
 			(async (): Promise<TranscriptionResult | undefined> => {
+				if (isLight) return undefined;
 				if (!stems?.bass) {
 					log.stageSkip("transcribe-bass", "no bass stem");
 					return undefined;
@@ -357,6 +360,7 @@ export async function bootstrap(source: string, options: BootstrapOptions = {}):
 
 			// Vocal MIDI (use lead vocals when available, fall back to full vocal stem)
 			(async (): Promise<TranscriptionResult | undefined> => {
+				if (isLight) return undefined;
 				const vocalSource = stems?.lead_vocals || stems?.vocals;
 				if (!vocalSource) {
 					log.stageSkip("transcribe-vocals", "no vocal stem");
@@ -380,6 +384,7 @@ export async function bootstrap(source: string, options: BootstrapOptions = {}):
 
 			// Drum MIDI
 			(async (): Promise<TranscriptionResult | undefined> => {
+				if (isLight) return undefined;
 				if (!stems?.drums) {
 					log.stageSkip("transcribe-drums", "no drum stem");
 					return undefined;
@@ -398,6 +403,7 @@ export async function bootstrap(source: string, options: BootstrapOptions = {}):
 
 			// Other MIDI (lower confidence)
 			(async (): Promise<TranscriptionResult | undefined> => {
+				if (isLight) return undefined;
 				if (!stems?.other) {
 					log.stageSkip("transcribe-other", "no other stem");
 					return undefined;
@@ -416,6 +422,7 @@ export async function bootstrap(source: string, options: BootstrapOptions = {}):
 
 			// Backing vocal MIDI (only when polyphony detected and lead isolated)
 			(async (): Promise<TranscriptionResult | undefined> => {
+				if (isLight) return undefined;
 				if (!stems?.backing_vocals) {
 					return undefined;
 				}
@@ -589,6 +596,9 @@ export async function bootstrap(source: string, options: BootstrapOptions = {}):
 		const provenance: Record<string, AnalysisProvenance> = {};
 
 		provenance.fingerprint = { tool: "fpcalc", version: "1.6.0", date: today };
+		if (isLight) {
+			provenance.mode = { tool: "light", date: today };
+		}
 
 		if (stems) {
 			provenance.separation = { tool: "demucs", version: "htdemucs", date: today };

--- a/src/bootstrap/scripts/detect_vocal_onset.py
+++ b/src/bootstrap/scripts/detect_vocal_onset.py
@@ -1,0 +1,40 @@
+"""Detect first vocal onset in a wav file via RMS energy threshold."""
+
+import sys
+import json
+import numpy as np
+import soundfile as sf
+
+def detect_vocal_onset(path: str, frame_ms: int = 50, threshold_db: float = -40.0) -> dict:
+    audio, sr = sf.read(path)
+    if audio.ndim > 1:
+        audio = audio.mean(axis=1)
+
+    frame_len = int(sr * frame_ms / 1000)
+    hop = frame_len
+
+    threshold_linear = 10 ** (threshold_db / 20)
+
+    for i in range(0, len(audio) - frame_len, hop):
+        frame = audio[i : i + frame_len]
+        rms = np.sqrt(np.mean(frame ** 2))
+        if rms > threshold_linear:
+            onset_ms = int(i / sr * 1000)
+            return {"onset_ms": onset_ms, "rms_db": round(20 * np.log10(rms + 1e-10), 1)}
+
+    return {"onset_ms": -1, "rms_db": None}
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: detect_vocal_onset.py <vocal_stem.wav> [--threshold-db <dB>]", file=sys.stderr)
+        sys.exit(1)
+
+    path = sys.argv[1]
+    threshold = -40.0
+    for i, arg in enumerate(sys.argv):
+        if arg == "--threshold-db" and i + 1 < len(sys.argv):
+            threshold = float(sys.argv[i + 1])
+
+    result = detect_vocal_onset(path, threshold_db=threshold)
+    print(json.dumps(result))

--- a/src/bootstrap/stages/lyric-offset.ts
+++ b/src/bootstrap/stages/lyric-offset.ts
@@ -1,0 +1,123 @@
+import type { LyricLine, WordEvent } from "../../../schema/map";
+
+interface TextCluster {
+	t: number;
+	text: string;
+}
+
+export interface LyricOffsetResult {
+	lyrics: LyricLine[];
+	offsetMs: number;
+	accepted: boolean;
+	avgSimilarity: number;
+	zeroSimilarity: number;
+}
+
+const SIMILARITY_THRESHOLD = 0.25;
+const IMPROVEMENT_THRESHOLD = 0.15;
+const MIN_OFFSET_MS = 2000;
+
+function clusterWords(words: WordEvent[], gapMs: number = 1000): TextCluster[] {
+	if (!words.length) return [];
+	const sorted = [...words].sort((a, b) => a.t - b.t);
+	const clusters: TextCluster[] = [];
+	let current = { t: sorted[0].t, texts: [sorted[0].text] };
+
+	for (let i = 1; i < sorted.length; i++) {
+		if (sorted[i].t - sorted[i - 1].t > gapMs) {
+			clusters.push({ t: current.t, text: current.texts.join(" ") });
+			current = { t: sorted[i].t, texts: [sorted[i].text] };
+		} else {
+			current.texts.push(sorted[i].text);
+		}
+	}
+	clusters.push({ t: current.t, text: current.texts.join(" ") });
+	return clusters;
+}
+
+function normalize(text: string): Set<string> {
+	return new Set(
+		text
+			.toLowerCase()
+			.replace(/[^a-z0-9\s]/g, "")
+			.split(/\s+/)
+			.filter((w) => w.length > 0),
+	);
+}
+
+function jaccard(a: Set<string>, b: Set<string>): number {
+	if (a.size === 0 && b.size === 0) return 0;
+	let intersection = 0;
+	for (const w of a) {
+		if (b.has(w)) intersection++;
+	}
+	const union = a.size + b.size - intersection;
+	return union > 0 ? intersection / union : 0;
+}
+
+function scoreAtOffset(
+	lines: { t: number; words: Set<string> }[],
+	clusters: { t: number; words: Set<string> }[],
+	delta: number,
+	toleranceMs: number,
+): number {
+	let total = 0;
+	for (const line of lines) {
+		const shifted = line.t + delta;
+		let bestSim = 0;
+		for (const cl of clusters) {
+			if (Math.abs(shifted - cl.t) <= toleranceMs) {
+				const sim = jaccard(line.words, cl.words);
+				if (sim > bestSim) bestSim = sim;
+			}
+		}
+		total += bestSim;
+	}
+	return total;
+}
+
+export function detectLyricOffset(
+	lyrics: LyricLine[],
+	words: WordEvent[],
+): LyricOffsetResult {
+	const clusters = clusterWords(words);
+	const linesNormed = lyrics.map((l) => ({ t: l.t, words: normalize(l.text) }));
+	const clustersNormed = clusters.map((c) => ({ t: c.t, words: normalize(c.text) }));
+
+	const rangeMs = 120_000;
+	const stepMs = 500;
+	const toleranceMs = 3000;
+
+	const zeroScore = scoreAtOffset(linesNormed, clustersNormed, 0, toleranceMs);
+	let bestOffset = 0;
+	let bestScore = zeroScore;
+
+	for (let delta = -rangeMs; delta <= rangeMs; delta += stepMs) {
+		const score = scoreAtOffset(linesNormed, clustersNormed, delta, toleranceMs);
+		if (score > bestScore) {
+			bestScore = score;
+			bestOffset = delta;
+		}
+	}
+
+	const avgSimilarity = lyrics.length > 0 ? bestScore / lyrics.length : 0;
+	const zeroSimilarity = lyrics.length > 0 ? zeroScore / lyrics.length : 0;
+	const improvement = avgSimilarity - zeroSimilarity;
+
+	const accepted =
+		Math.abs(bestOffset) > MIN_OFFSET_MS &&
+		avgSimilarity >= SIMILARITY_THRESHOLD &&
+		improvement >= IMPROVEMENT_THRESHOLD;
+
+	if (!accepted) {
+		return { lyrics, offsetMs: 0, accepted: false, avgSimilarity: zeroSimilarity, zeroSimilarity };
+	}
+
+	const corrected = lyrics.map((line) => ({
+		...line,
+		t: Math.max(0, line.t + bestOffset),
+		...(line.end != null ? { end: Math.max(0, line.end + bestOffset) } : {}),
+	}));
+
+	return { lyrics: corrected, offsetMs: bestOffset, accepted: true, avgSimilarity, zeroSimilarity };
+}


### PR DESCRIPTION
## Summary
- **`--light` flag** for bootstrap and batch pipelines (~65s/song vs ~147s). Produces demo-ready maps with lyrics, per-word timestamps, chords, and beats — skips MIDI transcription, polyphony/vocal split, and Haiku word reconciliation.
- **Lyric offset correction** (`lyric-offset` stage) detects and fixes YouTube intro silence that shifts LRCLIB lyrics. Uses sliding-window Jaccard text similarity between LRCLIB lines and WhisperX word clusters to find the best global offset. Applies correction when confidence is high (≥25% avg similarity, ≥15% improvement over no correction).
- Replaces the old `lrclibValidated`/`lrclibOffsetMs`-based offset correction with the text-similarity approach.

## Files changed
- `src/bootstrap/index.ts` — `light` option on `BootstrapOptions`, skip guards for MIDI/polyphony/reconciliation, wired in `detectLyricOffset`
- `src/bootstrap/cli.ts` — `--light` flag parsing
- `src/bootstrap/batch.ts` — `--light` flag parsing + threading to `bootstrap()`
- `src/bootstrap/stages/lyric-offset.ts` — new stage: sliding window offset detection
- `src/bootstrap/scripts/detect_vocal_onset.py` — RMS vocal onset detector (used in testing)
- `CLAUDE.md` — documented light mode and lyric offset correction

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Light mode tested on 3-song batch (65s avg, all succeeded)
- [x] Lyric offset tested on 4 songs: Wonderwall (15s offset corrected, 94% match), Revolution (correctly rejected, no correction needed), Wish You Were Here (corrected -15.5s), The Nitty Gritty (edge case — low WhisperX quality, not corrected)
- [ ] Full test suite (`bun test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)