### PR TITLE
feat(bootstrap): disable Haiku reconciliation, tune lyric offset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,8 +109,7 @@ Maps are JSON files describing the structure of a recording:
   `chords`, `beats`, `sections`, `midi`, `analysis`, `corrections`
 - `lyrics` and `words` are independent peer arrays (Model C). `lyrics`
   has line-level text from lyric databases. `words` has per-word
-  timestamps from WhisperX transcription, reconciled against LRCLIB
-  canonical text via Claude Haiku. A map can have one, both, or
+  timestamps from WhisperX transcription. A map can have one, both, or
   neither. Note: LRCLIB `end` timestamps on lyric lines are
   unreliable — they're always "next line start," not when the vocal
   actually ends. The `words` array is the authoritative timing source.
@@ -173,9 +172,7 @@ Generates maps from audio/video sources (~147s per song full,
      word-level alignment (WhisperX on vocal stem) →
      lyric offset correction (sliding-window Jaccard text similarity
      between LRCLIB lines and WhisperX clusters — detects and
-     corrects YouTube intro offset) →
-     word reconciliation (Claude Haiku corrects WhisperX text
-     against LRCLIB canonical lyrics)
+     corrects YouTube intro offset)
    - Audio analysis (essentia → chords, beats, key, tempo)
    - Per-stem MIDI transcription: drums (librosa), bass
      (basic-pitch + pitch bends), vocals (torchcrepe + expressive:
@@ -227,8 +224,8 @@ videos may be taken down or replaced. Spot-check before bulk runs.
 
 `--light` produces demo-ready maps (~65s/song) with lyrics,
 per-word timestamps, chords, and beats — skipping MIDI
-transcription, polyphony/vocal splitting, and Claude Haiku word
-reconciliation. Demucs still runs (vocal stem needed for WhisperX).
+transcription and polyphony/vocal splitting. Demucs still runs
+(vocal stem needed for WhisperX).
 
 ```bash
 bun run bootstrap <source> --light           # Single song
@@ -237,7 +234,7 @@ bun run batch songs.json --light --limit 10  # Batch
 
 Skipped stages: polyphony detection, MelBand RoFormer lead/backing
 split, all 5 MIDI transcriptions, MIDI beat alignment,
-cross-validation, Haiku word reconciliation. Light-mode maps have
+cross-validation. Light-mode maps have
 `analysis.mode.tool === "light"` in provenance.
 
 ### Lyric offset correction
@@ -343,10 +340,12 @@ reference document.
 - **MelBand RoFormer** for lead/backing vocal separation: Best
   published quality (SDR 11.1 dB lead) via python-audio-separator.
   Only runs when the polyphony detection gate fires.
-- **Claude Haiku** for word reconciliation: Corrects WhisperX
-  transcription errors against LRCLIB canonical lyrics. Sparse
-  corrections (~$0.004/song). Gracefully skips if `claude` CLI
-  unavailable.
+- **Claude Haiku** for word reconciliation: **Disabled.** The
+  infrastructure exists (`stages/reconcile-words.ts`) but Haiku
+  consistently returns zero corrections despite clear WhisperX
+  errors. The chunked line-bounded prompt approach was tested but
+  the model doesn't reliably identify corrections. Needs prompt
+  rework or a different model before re-enabling.
 
 ### Known limitations
 
@@ -354,14 +353,12 @@ reference document.
   (int8 compute type) because Apple's MPS GPU doesn't support float64
   operations. Alignment takes ~5-10s per song on CPU (acceptable).
 - **WhisperX text accuracy on sung lyrics.** WhisperX transcribes
-  what it hears, not canonical lyrics. Word reconciliation via Claude
-  Haiku corrects most errors, but ad-libs and vocal flourishes may
-  retain WhisperX's interpretation. The `lyrics` array carries
-  canonical LRCLIB text; the `words` array carries reconciled text
-  with WhisperX timing.
+  what it hears, not canonical lyrics. The `words` array carries
+  raw WhisperX text (no reconciliation). The `lyrics` array carries
+  canonical LRCLIB text. Players should prefer `lyrics` for display
+  text and `words` for timing.
 - **LRCLIB validation non-determinism.** WhisperX temperature
   sampling causes inconsistent mismatch detection across runs.
-  The offset correction (>2s threshold) mitigates the worst cases.
 - **Bass-chord concordance is low (13-42%):** The cross-validation
   between bass MIDI pitch classes and chord roots produces mostly
   noise. Likely caused by basic-pitch quality on bass frequencies

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -22,7 +22,7 @@ import {
 	lookupLyrics,
 	searchLyrics,
 } from "./stages/lyrics";
-import { reconcileWords } from "./stages/reconcile-words";
+
 import { type StemPaths, separateAudio, separateVocals } from "./stages/separate";
 import { type TranscriptionResult, transcribeStem } from "./stages/transcribe";
 import { detectLyricOffset } from "./stages/lyric-offset";
@@ -260,24 +260,7 @@ export async function bootstrap(source: string, options: BootstrapOptions = {}):
 					}
 				}
 
-				// Word reconciliation: correct WhisperX text against LRCLIB canonical lyrics
-				let wordsReconciled = false;
-				if (!isLight && words?.length && correctedLyrics?.length) {
-					try {
-						const reconciled = await reconcileWords(words, correctedLyrics, { title, artist });
-						if (reconciled.correctionCount > 0) {
-							words = reconciled.words;
-							wordsReconciled = true;
-							log.stageOk("reconcile-words", `${reconciled.correctionCount} corrections applied`);
-						} else {
-							log.stageOk("reconcile-words", "no corrections needed");
-						}
-					} catch (err) {
-						log.stageFail("reconcile-words", err instanceof Error ? err.message : String(err));
-					}
-				}
-
-				return { lyrics: correctedLyrics, words, lrclibValidated, wordsReconciled };
+				return { lyrics: correctedLyrics, words, lrclibValidated, wordsReconciled: false };
 			})(),
 
 			// Analysis (unchanged)
@@ -655,13 +638,6 @@ export async function bootstrap(source: string, options: BootstrapOptions = {}):
 			map.words = lyricsResult.words;
 			const wordTool = lyricsResult.lrclibValidated ? "whisperx+lrclib" : "whisperx";
 			provenance.words = { tool: wordTool, date: today };
-			if (lyricsResult.wordsReconciled) {
-				provenance["words-reconciled"] = {
-					tool: "claude-haiku",
-					version: "claude-haiku-4-5",
-					date: today,
-				};
-			}
 		}
 
 		if (finalChords?.length) {

--- a/src/bootstrap/stages/lyric-offset.ts
+++ b/src/bootstrap/stages/lyric-offset.ts
@@ -15,7 +15,7 @@ export interface LyricOffsetResult {
 
 const SIMILARITY_THRESHOLD = 0.25;
 const IMPROVEMENT_THRESHOLD = 0.15;
-const MIN_OFFSET_MS = 2000;
+const MIN_OFFSET_MS = 500;
 
 function clusterWords(words: WordEvent[], gapMs: number = 1000): TextCluster[] {
 	if (!words.length) return [];

--- a/src/bootstrap/stages/reconcile-words.ts
+++ b/src/bootstrap/stages/reconcile-words.ts
@@ -5,35 +5,75 @@ export interface ReconcileResult {
 	correctionCount: number;
 }
 
-const SYSTEM_PROMPT = `You reconcile word-level audio transcription with canonical lyrics for a song. You receive two representations:
+const SYSTEM_PROMPT = `You reconcile word-level audio transcription with canonical lyrics for a song. You receive lines grouped by timestamp window. Each group shows:
 
-1. LRCLIB lines: canonical text with line-start timestamps
-2. WhisperX words: transcribed text with per-word timestamps
+- The canonical LRCLIB text for that line
+- The WhisperX transcribed words (with indices) that fall in that time window
 
 Return JSON only: {"corrections": [{"i": <index>, "text": "<corrected>"}]}
 
 Rules:
 - Only include words that need text correction
-- Never add or remove words — only correct existing slots
+- Never add or remove words — only correct existing text at existing indices
 - Preserve original word boundaries (don't merge or split)
 - If a WhisperX word is an ad-lib or vocal flourish absent from LRCLIB, leave it unchanged
 - Prefer LRCLIB spelling/punctuation when the word clearly matches
 - If uncertain, leave unchanged`;
 
-function formatLrclibLines(lyrics: LyricLine[]): string {
-	return lyrics
-		.map((line) => {
-			const totalMs = line.t;
-			const minutes = Math.floor(totalMs / 60000);
-			const seconds = Math.floor((totalMs % 60000) / 1000);
-			const centiseconds = Math.floor((totalMs % 1000) / 10);
-			return `[${minutes}:${String(seconds).padStart(2, "0")}.${String(centiseconds).padStart(2, "0")}] ${line.text}`;
-		})
-		.join("\n");
+interface LineChunk {
+	lineText: string;
+	words: { index: number; text: string }[];
 }
 
-function formatWhisperXWords(words: WordEvent[]): string {
-	return words.map((w, i) => `${i}: "${w.text}" (${w.t}ms)`).join("\n");
+function buildChunks(lyrics: LyricLine[], words: WordEvent[]): LineChunk[] {
+	const sorted = [...words].map((w, i) => ({ ...w, origIndex: i })).sort((a, b) => a.t - b.t);
+	const chunks: LineChunk[] = [];
+
+	// Use midpoints between consecutive line starts as boundaries
+	const boundaries: number[] = [];
+	for (let l = 0; l < lyrics.length; l++) {
+		if (l === 0) {
+			boundaries.push(-Infinity);
+		} else {
+			boundaries.push((lyrics[l - 1].t + lyrics[l].t) / 2);
+		}
+	}
+
+	for (let l = 0; l < lyrics.length; l++) {
+		const windowStart = boundaries[l];
+		const windowEnd = l + 1 < boundaries.length ? boundaries[l + 1] : Number.POSITIVE_INFINITY;
+		const nextLineStart = l + 1 < lyrics.length ? (lyrics[l].t + lyrics[l + 1].t) / 2 : Number.POSITIVE_INFINITY;
+
+		const chunkWords: { index: number; text: string }[] = [];
+		for (const w of sorted) {
+			if (w.t >= windowStart && w.t < nextLineStart) {
+				chunkWords.push({ index: w.origIndex, text: w.text });
+			}
+		}
+
+		if (chunkWords.length > 0) {
+			chunks.push({ lineText: lyrics[l].text, words: chunkWords });
+		}
+	}
+
+	return chunks;
+}
+
+function formatChunkedPrompt(
+	chunks: LineChunk[],
+	metadata: { title?: string; artist?: string },
+): string {
+	const lines: string[] = [`Song: ${metadata.title || "Unknown"} by ${metadata.artist || "Unknown"}`, ""];
+
+	for (let c = 0; c < chunks.length; c++) {
+		const chunk = chunks[c];
+		lines.push(`Line ${c + 1} canonical: "${chunk.lineText}"`);
+		const wordList = chunk.words.map((w) => `${w.index}:"${w.text}"`).join(", ");
+		lines.push(`Line ${c + 1} transcribed: [${wordList}]`);
+		lines.push("");
+	}
+
+	return lines.join("\n");
 }
 
 interface Correction {
@@ -42,7 +82,6 @@ interface Correction {
 }
 
 function parseCorrections(raw: string): Correction[] | undefined {
-	// Try to extract JSON from the response (may be wrapped in markdown fences)
 	let jsonStr = raw.trim();
 	const fenceMatch = jsonStr.match(/```(?:json)?\s*([\s\S]*?)```/);
 	if (fenceMatch) {
@@ -63,23 +102,20 @@ export async function reconcileWords(
 	lyrics: LyricLine[],
 	metadata: { title?: string; artist?: string },
 ): Promise<ReconcileResult> {
-	// Fallback: empty lyrics means nothing to reconcile against
 	if (lyrics.length === 0) {
 		return { words, correctionCount: 0 };
 	}
 
-	// Check if claude CLI is available
 	if (!Bun.which("claude")) {
 		return { words, correctionCount: 0 };
 	}
 
-	const userPrompt = `Song: ${metadata.title || "Unknown"} by ${metadata.artist || "Unknown"}
+	const chunks = buildChunks(lyrics, words);
+	if (chunks.length === 0) {
+		return { words, correctionCount: 0 };
+	}
 
-LRCLIB lines:
-${formatLrclibLines(lyrics)}
-
-WhisperX words (${words.length} total):
-${formatWhisperXWords(words)}`;
+	const userPrompt = formatChunkedPrompt(chunks, metadata);
 
 	let stdout: string;
 	try {
@@ -98,24 +134,26 @@ ${formatWhisperXWords(words)}`;
 
 		stdout = await new Response(proc.stdout).text();
 	} catch {
+		console.error("[reconcile-words] claude CLI threw");
 		return { words, correctionCount: 0 };
 	}
+
+	console.error(`[reconcile-words] raw response (${stdout.length} chars): ${stdout.slice(0, 500)}`);
 
 	const corrections = parseCorrections(stdout);
 	if (!corrections) {
+		console.error("[reconcile-words] failed to parse corrections from response");
 		return { words, correctionCount: 0 };
 	}
 
-	// Apply valid corrections
+	console.error(`[reconcile-words] parsed ${corrections.length} corrections`);
+
 	const correctedWords = [...words];
 	let correctionCount = 0;
 
 	for (const c of corrections) {
-		// Discard out-of-bounds
 		if (c.i < 0 || c.i >= correctedWords.length) continue;
-		// Discard empty text
 		if (!c.text || c.text.trim().length === 0) continue;
-		// Discard no-ops
 		if (c.text === correctedWords[c.i].text) continue;
 
 		correctedWords[c.i] = { ...correctedWords[c.i], text: c.text };


### PR DESCRIPTION
## Summary
- **Haiku word reconciliation disabled** in both full and light pipeline modes. Consistently returned zero corrections despite clear WhisperX transcription errors. Tested with both full-song prompts and chunked line-bounded prompts — neither produced corrections. Infrastructure preserved in `reconcile-words.ts` for future rework with better prompting or a different model.
- **Lyric offset minimum threshold lowered** from 2s to 500ms for tighter LRCLIB-to-audio alignment.
- **CLAUDE.md updated** to document the decision and correct pipeline description.

## Test plan
- [x] TypeScript compiles clean
- [x] Pipeline runs without reconciliation stage
- [x] Lyric offset correction still fires on offset songs

🤖 Generated with [Claude Code](https://claude.com/claude-code)