### PR TITLE
fix(editor): repair GitHub auth and deep-link routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,11 +283,19 @@ and GitHub PR submission.
   non-overlapping sections, non-empty text, end > start, chord
   format warning). Red/amber borders on invalid events.
   Submission blocked on errors.
-- **GitHub submission:** Device flow OAuth (no server-side token
-  exchange). Forks repo, creates branch, commits corrected map,
-  opens PR with structured diff from EditAction history. PR body
-  includes machine-readable `<!-- pulsemap-correction -->` block
-  parsed by the corrections provenance GitHub Action.
+- **GitHub submission:** OAuth web flow. Browser redirects to GitHub
+  for authorization, returns with a code, then a small Netlify
+  Function (`netlify/functions/oauth-token.ts`) does the
+  code-for-token exchange server-side (GitHub's token endpoint
+  doesn't send CORS headers, so a direct browser exchange is
+  impossible). Function reads `GITHUB_CLIENT_ID`,
+  `GITHUB_CLIENT_SECRET`, and `ALLOWED_ORIGIN` from Netlify env
+  vars and runs at `https://pulsemap-editor.netlify.app/oauth/token`.
+  Once authed, the editor forks the repo, creates a branch, commits
+  the corrected map, and opens a PR with a structured diff from
+  EditAction history. PR body includes a machine-readable
+  `<!-- pulsemap-correction -->` block parsed by the corrections
+  provenance GitHub Action.
 - **SDK integration:** Any player calls `openEditor()` from
   `sdk/editor/` to send users here. Pulseguide has context-menu
   integration on chords, words, sections, lyrics.

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -51,24 +51,28 @@ function EditorContent({
 	position,
 	containerId,
 	playbackAvailable,
+	playbackReady,
 	onPlay,
 	onPause,
 	onSeek,
 	onRateChange,
 	ghToken,
 	onAuthChange,
+	deepLink,
 }: {
 	map: PulseMap;
 	playing: boolean;
 	position: number;
 	containerId: string;
 	playbackAvailable: boolean;
+	playbackReady: boolean;
 	onPlay: () => void;
 	onPause: () => void;
 	onSeek: (ms: number) => void;
 	onRateChange: (rate: number) => void;
 	ghToken: string | null;
 	onAuthChange: (token: string | null, login: string | null) => void;
+	deepLink: { t?: number; lane?: string; index?: number };
 }) {
 	const { state, dispatch } = useEditor();
 	const workingMap = state.working;
@@ -270,12 +274,14 @@ function EditorContent({
 				position={position}
 				playing={playing}
 				onSeek={onSeek}
+				playbackReady={playbackReady}
 				snapEnabled={snapEnabled}
 				snapSubdivision={snapSubdivision}
 				onSnapEnabledChange={setSnapEnabled}
 				onSnapSubdivisionChange={setSnapSubdivision}
 				validationIssues={validationIssues}
 				validationColorsByLane={validationColorsByLane}
+				deepLink={deepLink}
 			/>
 
 			{showSubmitFlow && ghToken && (
@@ -305,10 +311,22 @@ function EditorContent({
 
 export function App() {
 	const mapId = getMapId();
-	const params = parseEditorParams(window.location.search);
+	// Snapshot URL params once at mount; they get cleaned from the URL by the
+	// SPA fallback rewrite and shouldn't be re-read on every render.
+	const deepLinkRef = useRef(parseEditorParams(window.location.search));
+	const deepLink = deepLinkRef.current;
 	const { map, loading, error } = useMap(mapId);
-	const { containerId, play, pause, seek, setRate, playbackAvailable, playing, position } =
-		usePlayback(map);
+	const {
+		containerId,
+		play,
+		pause,
+		seek,
+		setRate,
+		playbackAvailable,
+		playbackReady,
+		playing,
+		position,
+	} = usePlayback(map);
 
 	// --- GitHub OAuth state ---
 	const [ghToken, setGhToken] = useState<string | null>(null);
@@ -332,11 +350,6 @@ export function App() {
 		setGhToken(token);
 		setGhLogin(login);
 	}, []);
-
-	// Seek to ?t= param on first load
-	if (params.t != null && map && playbackAvailable && position === 0) {
-		seek(params.t);
-	}
 
 	if (!mapId) {
 		return (
@@ -380,12 +393,14 @@ export function App() {
 					position={position}
 					containerId={containerId}
 					playbackAvailable={playbackAvailable}
+					playbackReady={playbackReady}
 					onPlay={play}
 					onPause={pause}
 					onSeek={seek}
 					onRateChange={setRate}
 					ghToken={ghToken}
 					onAuthChange={handleAuthChange}
+					deepLink={deepLink}
 				/>
 			</EditorProvider>
 		</div>

--- a/editor/src/components/GitHubAuth.tsx
+++ b/editor/src/components/GitHubAuth.tsx
@@ -1,13 +1,5 @@
 import { type CSSProperties, useCallback, useEffect, useState } from "react";
-import {
-	clearToken,
-	type DeviceCodeResponse,
-	getStoredToken,
-	pollForToken,
-	requestDeviceCode,
-	storeToken,
-	validateToken,
-} from "../github/auth";
+import { beginOAuth, clearToken, getStoredToken, validateToken } from "../github/auth";
 
 interface GitHubAuthProps {
 	onAuthChange: (token: string | null, login: string | null) => void;
@@ -16,8 +8,6 @@ interface GitHubAuthProps {
 export function GitHubAuth({ onAuthChange }: GitHubAuthProps) {
 	const [login, setLogin] = useState<string | null>(null);
 	const [checking, setChecking] = useState(true);
-	const [deviceFlow, setDeviceFlow] = useState<DeviceCodeResponse | null>(null);
-	const [error, setError] = useState<string | null>(null);
 
 	useEffect(() => {
 		const token = getStoredToken();
@@ -39,26 +29,9 @@ export function GitHubAuth({ onAuthChange }: GitHubAuthProps) {
 		});
 	}, [onAuthChange]);
 
-	const handleSignIn = useCallback(async () => {
-		setError(null);
-		try {
-			const device = await requestDeviceCode();
-			setDeviceFlow(device);
-
-			const token = await pollForToken(device.device_code, device.interval);
-			storeToken(token);
-			setDeviceFlow(null);
-
-			const user = await validateToken(token);
-			if (user) {
-				setLogin(user.login);
-				onAuthChange(token, user.login);
-			}
-		} catch (err) {
-			setError(err instanceof Error ? err.message : "Auth failed");
-			setDeviceFlow(null);
-		}
-	}, [onAuthChange]);
+	const handleSignIn = useCallback(() => {
+		beginOAuth();
+	}, []);
 
 	const handleSignOut = useCallback(() => {
 		clearToken();
@@ -81,29 +54,11 @@ export function GitHubAuth({ onAuthChange }: GitHubAuthProps) {
 		);
 	}
 
-	if (deviceFlow) {
-		return (
-			<span style={styles.deviceFlow}>
-				<span style={styles.deviceLabel}>Enter code at</span>
-				<a
-					href={deviceFlow.verification_uri}
-					target="_blank"
-					rel="noopener noreferrer"
-					style={styles.deviceLink}
-				>
-					{deviceFlow.verification_uri}
-				</a>
-				<code style={styles.deviceCode}>{deviceFlow.user_code}</code>
-			</span>
-		);
-	}
-
 	return (
 		<span style={styles.wrapper}>
 			<button type="button" onClick={handleSignIn} style={styles.signIn}>
 				Sign in with GitHub
 			</button>
-			{error && <span style={styles.error}>{error}</span>}
 		</span>
 	);
 }
@@ -139,32 +94,5 @@ const styles: Record<string, CSSProperties> = {
 		color: "#8b949e",
 		fontSize: 11,
 		cursor: "pointer",
-	},
-	deviceFlow: {
-		display: "inline-flex",
-		alignItems: "center",
-		gap: 8,
-		fontSize: 12,
-	},
-	deviceLabel: {
-		color: "#8b949e",
-	},
-	deviceLink: {
-		color: "#58a6ff",
-		textDecoration: "none",
-	},
-	deviceCode: {
-		padding: "2px 8px",
-		background: "#21262d",
-		border: "1px solid #363b42",
-		borderRadius: 4,
-		color: "#ffd93d",
-		fontSize: 14,
-		fontWeight: 600,
-		letterSpacing: 2,
-	},
-	error: {
-		color: "#f85149",
-		fontSize: 11,
 	},
 };

--- a/editor/src/components/Timeline.tsx
+++ b/editor/src/components/Timeline.tsx
@@ -3,7 +3,7 @@ import { type CSSProperties, useCallback, useEffect, useRef, useState } from "re
 import { COLORS, LANE_ORDER, type LaneName } from "../constants";
 import { type SnapSubdivision, useBeatSnap } from "../hooks/useBeatSnap";
 import { useTimeline } from "../hooks/useTimeline";
-import { deselectAction } from "../state/actions";
+import { deselectAction, selectAction } from "../state/actions";
 import { useEditor } from "../state/context";
 import type { EditableLane } from "../state/types";
 import type { ValidationIssue } from "../validation/types";
@@ -21,12 +21,51 @@ interface TimelineProps {
 	position: number;
 	playing: boolean;
 	onSeek: (ms: number) => void;
+	playbackReady: boolean;
 	snapEnabled: boolean;
 	snapSubdivision: SnapSubdivision;
 	onSnapEnabledChange: (enabled: boolean) => void;
 	onSnapSubdivisionChange: (subdivision: SnapSubdivision) => void;
 	validationIssues: ValidationIssue[];
 	validationColorsByLane: Map<EditableLane, Map<number, string>>;
+	deepLink: { t?: number; lane?: string; index?: number };
+}
+
+const EDITABLE_LANES: ReadonlySet<string> = new Set(["chords", "words", "lyrics", "sections"]);
+
+function laneEventCount(map: PulseMap, lane: EditableLane): number {
+	switch (lane) {
+		case "chords":
+			return map.chords?.length ?? 0;
+		case "words":
+			return map.words?.length ?? 0;
+		case "lyrics":
+			return map.lyrics?.length ?? 0;
+		case "sections":
+			return map.sections?.length ?? 0;
+	}
+}
+
+function nearestIndexAtT(map: PulseMap, lane: EditableLane, t: number): number | null {
+	const arr =
+		lane === "chords"
+			? map.chords
+			: lane === "words"
+				? map.words
+				: lane === "lyrics"
+					? map.lyrics
+					: map.sections;
+	if (!arr || arr.length === 0) return null;
+	let best = 0;
+	let bestDist = Math.abs(arr[0].t - t);
+	for (let i = 1; i < arr.length; i++) {
+		const d = Math.abs(arr[i].t - t);
+		if (d < bestDist) {
+			bestDist = d;
+			best = i;
+		}
+	}
+	return best;
 }
 
 function hasLaneData(map: PulseMap, lane: LaneName): boolean {
@@ -48,12 +87,14 @@ export function Timeline({
 	position,
 	playing,
 	onSeek,
+	playbackReady,
 	snapEnabled,
 	snapSubdivision,
 	onSnapEnabledChange,
 	onSnapSubdivisionChange,
 	validationIssues,
 	validationColorsByLane,
+	deepLink,
 }: TimelineProps) {
 	const { state, dispatch } = useEditor();
 	const workingMap = state.working;
@@ -77,6 +118,7 @@ export function Timeline({
 		containerRef,
 		enableFollow,
 		disableFollow,
+		setScrollMs,
 		zoomIn,
 		zoomOut,
 	} = useTimeline({
@@ -84,6 +126,62 @@ export function Timeline({
 		position,
 		playing,
 	});
+
+	// Deep-link routing: ?t=&lane=&index= drives scroll, seek, and selection.
+	// Runs once after the player is ready so the seek isn't dropped.
+	const deepLinkApplied = useRef(false);
+	useEffect(() => {
+		if (deepLinkApplied.current) return;
+		const { t, lane, index } = deepLink;
+		const hasTarget = t != null || (lane && EDITABLE_LANES.has(lane));
+		if (!hasTarget) {
+			deepLinkApplied.current = true;
+			return;
+		}
+		if (t != null && !playbackReady) return;
+		deepLinkApplied.current = true;
+
+		if (t != null) {
+			onSeek(t);
+			disableFollow();
+			const el = containerRef.current;
+			if (el) {
+				const viewportMs = el.clientWidth / pxPerMs;
+				const targetScroll = Math.max(0, t - viewportMs * 0.25);
+				const maxScrollMs = Math.max(
+					0,
+					workingMap.duration_ms - (el.clientWidth - 72) / pxPerMs,
+				);
+				setScrollMs(Math.min(targetScroll, maxScrollMs));
+			} else {
+				setScrollMs(Math.max(0, t - 1000));
+			}
+		}
+
+		if (lane && EDITABLE_LANES.has(lane)) {
+			const editableLane = lane as EditableLane;
+			const count = laneEventCount(workingMap, editableLane);
+			if (count > 0) {
+				let resolvedIndex: number | null | undefined = index;
+				if (resolvedIndex == null && t != null) {
+					resolvedIndex = nearestIndexAtT(workingMap, editableLane, t);
+				}
+				if (resolvedIndex != null && resolvedIndex >= 0 && resolvedIndex < count) {
+					dispatch(selectAction(editableLane, resolvedIndex));
+				}
+			}
+		}
+	}, [
+		deepLink,
+		playbackReady,
+		onSeek,
+		disableFollow,
+		setScrollMs,
+		pxPerMs,
+		containerRef,
+		workingMap,
+		dispatch,
+	]);
 
 	const { snapToNearestBeat } = useBeatSnap({
 		beats: workingMap.beats,

--- a/editor/src/components/Timeline.tsx
+++ b/editor/src/components/Timeline.tsx
@@ -148,10 +148,7 @@ export function Timeline({
 			if (el) {
 				const viewportMs = el.clientWidth / pxPerMs;
 				const targetScroll = Math.max(0, t - viewportMs * 0.25);
-				const maxScrollMs = Math.max(
-					0,
-					workingMap.duration_ms - (el.clientWidth - 72) / pxPerMs,
-				);
+				const maxScrollMs = Math.max(0, workingMap.duration_ms - (el.clientWidth - 72) / pxPerMs);
 				setScrollMs(Math.min(targetScroll, maxScrollMs));
 			} else {
 				setScrollMs(Math.max(0, t - 1000));

--- a/editor/src/github/auth.ts
+++ b/editor/src/github/auth.ts
@@ -1,103 +1,105 @@
 /**
- * GitHub OAuth device flow: no server-side token exchange needed.
+ * GitHub OAuth web flow.
+ *
+ * GitHub's /login/oauth/access_token endpoint doesn't send CORS headers,
+ * so the code-for-token exchange goes through a small Netlify Function
+ * proxy. The browser only handles the redirect to GitHub and the return.
  *
  * Flow:
- * 1. POST /login/device/code → get device_code, user_code, verification_uri
- * 2. Show user the code and link
- * 3. Poll /login/oauth/access_token until user authorizes
+ * 1. beginOAuth() — generates a CSRF state, stashes it + the current URL
+ *    in sessionStorage, redirects to github.com/login/oauth/authorize.
+ * 2. GitHub redirects back to redirect_uri with ?code=&state=.
+ * 3. handleOAuthCallback() — runs at app boot, verifies state, calls the
+ *    proxy to exchange code for token, stores token, restores the
+ *    pre-auth URL, and strips the OAuth params.
  */
 
-const CLIENT_ID = "Ov23li12vkglROrSw2N1";
-
+const CLIENT_ID = "Ov23liuBjPclnX0rAr1s";
 const TOKEN_KEY = "pulsemap-gh-token";
+const STATE_KEY = "pulsemap-oauth-state";
+const RETURN_URL_KEY = "pulsemap-oauth-return-url";
+const REDIRECT_URI = "https://hartphoenix.github.io/pulsemap/editor/";
 
-export interface DeviceCodeResponse {
-	device_code: string;
-	user_code: string;
-	verification_uri: string;
-	expires_in: number;
-	interval: number;
+const PROXY_URL =
+	(import.meta.env?.VITE_OAUTH_PROXY_URL as string | undefined) ??
+	"https://pulsemap-editor.netlify.app";
+
+function randomState(): string {
+	const bytes = new Uint8Array(16);
+	crypto.getRandomValues(bytes);
+	return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-/** Request a device code from GitHub. */
-export async function requestDeviceCode(): Promise<DeviceCodeResponse> {
-	const res = await fetch("https://github.com/login/device/code", {
-		method: "POST",
-		headers: {
-			Accept: "application/json",
-			"Content-Type": "application/json",
-		},
-		body: JSON.stringify({
-			client_id: CLIENT_ID,
-			scope: "public_repo",
-		}),
-	});
+/** Redirect to GitHub to begin the OAuth web flow. */
+export function beginOAuth(): void {
+	const state = randomState();
+	sessionStorage.setItem(STATE_KEY, state);
+	sessionStorage.setItem(
+		RETURN_URL_KEY,
+		window.location.pathname + window.location.search + window.location.hash,
+	);
 
-	if (!res.ok) {
-		throw new Error(`Device code request failed: ${res.status}`);
-	}
-
-	return (await res.json()) as DeviceCodeResponse;
+	const authUrl = new URL("https://github.com/login/oauth/authorize");
+	authUrl.searchParams.set("client_id", CLIENT_ID);
+	authUrl.searchParams.set("scope", "public_repo");
+	authUrl.searchParams.set("state", state);
+	authUrl.searchParams.set("redirect_uri", REDIRECT_URI);
+	window.location.assign(authUrl.toString());
 }
 
 /**
- * Poll for the access token after user enters the device code.
- * Resolves with the token when authorized, rejects on expiry or denial.
+ * If the current URL is an OAuth callback (has ?code=&state=), verify
+ * the state, exchange the code for a token, persist it, and restore the
+ * pre-auth URL. Returns true if a callback was handled (whether or not
+ * it succeeded). Safe to call when there's no callback in the URL.
+ *
+ * Should run before React mounts so the URL is clean when the editor
+ * reads its deep-link params.
  */
-export async function pollForToken(deviceCode: string, interval: number): Promise<string> {
-	const pollInterval = Math.max(interval, 5) * 1000;
+export async function handleOAuthCallback(): Promise<boolean> {
+	const params = new URLSearchParams(window.location.search);
+	const code = params.get("code");
+	const state = params.get("state");
+	if (!code || !state) return false;
 
-	while (true) {
-		await new Promise((r) => setTimeout(r, pollInterval));
+	const expected = sessionStorage.getItem(STATE_KEY);
+	const returnUrl = sessionStorage.getItem(RETURN_URL_KEY);
+	sessionStorage.removeItem(STATE_KEY);
+	sessionStorage.removeItem(RETURN_URL_KEY);
 
-		const res = await fetch("https://github.com/login/oauth/access_token", {
-			method: "POST",
-			headers: {
-				Accept: "application/json",
-				"Content-Type": "application/json",
-			},
-			body: JSON.stringify({
-				client_id: CLIENT_ID,
-				device_code: deviceCode,
-				grant_type: "urn:ietf:params:oauth:grant-type:device_code",
-			}),
-		});
+	const restore = () => {
+		const target = returnUrl ?? window.location.pathname + window.location.hash;
+		window.history.replaceState(null, "", target);
+	};
 
-		if (!res.ok) continue;
-
-		const data = (await res.json()) as {
-			access_token?: string;
-			error?: string;
-		};
-
-		if (data.access_token) {
-			return data.access_token;
-		}
-
-		if (data.error === "authorization_pending") continue;
-		if (data.error === "slow_down") {
-			await new Promise((r) => setTimeout(r, 5000));
-			continue;
-		}
-		if (data.error === "expired_token") {
-			throw new Error("Device code expired. Please try again.");
-		}
-		if (data.error === "access_denied") {
-			throw new Error("Authorization denied by user.");
-		}
-
-		throw new Error(`Unexpected error: ${data.error}`);
+	if (!expected || expected !== state) {
+		restore();
+		return true;
 	}
+
+	try {
+		const res = await fetch(`${PROXY_URL}/oauth/token`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ code, redirect_uri: REDIRECT_URI }),
+		});
+		if (res.ok) {
+			const data = (await res.json()) as { access_token?: string };
+			if (data.access_token) {
+				localStorage.setItem(TOKEN_KEY, data.access_token);
+			}
+		}
+	} catch {
+		// network error — token not stored; user will see signed-out state
+	}
+
+	restore();
+	return true;
 }
 
 /** Read stored token from localStorage. */
 export function getStoredToken(): string | null {
 	return localStorage.getItem(TOKEN_KEY);
-}
-
-/** Persist a token to localStorage. */
-export function storeToken(token: string): void {
-	localStorage.setItem(TOKEN_KEY, token);
 }
 
 /** Remove the stored token. */

--- a/editor/src/hooks/usePlayback.ts
+++ b/editor/src/hooks/usePlayback.ts
@@ -14,6 +14,8 @@ interface UsePlaybackResult {
 	setRate: (rate: number) => void;
 	/** Whether a YouTube playback target was found */
 	playbackAvailable: boolean;
+	/** Whether the player has emitted onReady (seek calls before this are no-ops) */
+	playbackReady: boolean;
 	/** Whether currently playing */
 	playing: boolean;
 	/** Current position in ms */
@@ -40,6 +42,7 @@ export function usePlayback(map: PulseMap | null): UsePlaybackResult {
 	const [playing, setPlaying] = useState(false);
 	const [position, setPosition] = useState(0);
 	const [playbackAvailable, setPlaybackAvailable] = useState(false);
+	const [playbackReady, setPlaybackReady] = useState(false);
 
 	const videoId = map ? findYouTubeVideoId(map) : null;
 
@@ -50,6 +53,8 @@ export function usePlayback(map: PulseMap | null): UsePlaybackResult {
 			adapterRef.current.destroy();
 			adapterRef.current = null;
 		}
+
+		setPlaybackReady(false);
 
 		if (!videoId) {
 			setPlaybackAvailable(false);
@@ -71,6 +76,9 @@ export function usePlayback(map: PulseMap | null): UsePlaybackResult {
 		});
 		adapterRef.current = adapter;
 		setPlaybackAvailable(true);
+		adapter.waitForReady().then(() => {
+			if (adapterRef.current === adapter) setPlaybackReady(true);
+		});
 
 		const unsubscribe = adapter.onStateChange((state: PlaybackState) => {
 			setPlaying(state === "playing");
@@ -105,6 +113,7 @@ export function usePlayback(map: PulseMap | null): UsePlaybackResult {
 		seek,
 		setRate,
 		playbackAvailable,
+		playbackReady,
 		playing,
 		position,
 	};

--- a/editor/src/main.tsx
+++ b/editor/src/main.tsx
@@ -1,11 +1,15 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import { handleOAuthCallback } from "./github/auth";
 
 const rootEl = document.getElementById("root");
 if (!rootEl) throw new Error("Root element not found");
-createRoot(rootEl).render(
-	<StrictMode>
-		<App />
-	</StrictMode>,
-);
+
+handleOAuthCallback().finally(() => {
+	createRoot(rootEl).render(
+		<StrictMode>
+			<App />
+		</StrictMode>,
+	);
+});

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+[build]
+  command = ":"
+  publish = "netlify-empty"
+  functions = "netlify/functions"
+
+[[redirects]]
+  from = "/oauth/token"
+  to = "/.netlify/functions/oauth-token"
+  status = 200

--- a/netlify/functions/oauth-token.ts
+++ b/netlify/functions/oauth-token.ts
@@ -62,29 +62,29 @@ export default async (req: Request): Promise<Response> => {
 	}
 
 	if (!clientId || !clientSecret) {
-		return new Response(
-			JSON.stringify({ error: "server_misconfigured" }),
-			{ status: 500, headers: { ...cors, "Content-Type": "application/json" } },
-		);
+		return new Response(JSON.stringify({ error: "server_misconfigured" }), {
+			status: 500,
+			headers: { ...cors, "Content-Type": "application/json" },
+		});
 	}
 
 	let body: ExchangeRequest;
 	try {
 		body = (await req.json()) as ExchangeRequest;
 	} catch {
-		return new Response(
-			JSON.stringify({ error: "invalid_json" }),
-			{ status: 400, headers: { ...cors, "Content-Type": "application/json" } },
-		);
+		return new Response(JSON.stringify({ error: "invalid_json" }), {
+			status: 400,
+			headers: { ...cors, "Content-Type": "application/json" },
+		});
 	}
 
 	const code = typeof body.code === "string" ? body.code : null;
 	const redirectUri = typeof body.redirect_uri === "string" ? body.redirect_uri : undefined;
 	if (!code) {
-		return new Response(
-			JSON.stringify({ error: "missing_code" }),
-			{ status: 400, headers: { ...cors, "Content-Type": "application/json" } },
-		);
+		return new Response(JSON.stringify({ error: "missing_code" }), {
+			status: 400,
+			headers: { ...cors, "Content-Type": "application/json" },
+		});
 	}
 
 	const ghRes = await fetch("https://github.com/login/oauth/access_token", {

--- a/netlify/functions/oauth-token.ts
+++ b/netlify/functions/oauth-token.ts
@@ -1,0 +1,124 @@
+/**
+ * OAuth token-exchange proxy for the PulseMap Editor.
+ *
+ * GitHub's /login/oauth/access_token endpoint does not send CORS headers,
+ * so a browser app on github.io cannot exchange an authorization code
+ * directly. This function does the exchange server-side and returns the
+ * token to the editor with a precise Access-Control-Allow-Origin header.
+ *
+ * Required env: GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, ALLOWED_ORIGIN
+ *   (ALLOWED_ORIGIN may be a comma-separated list, e.g. for localhost dev)
+ */
+
+interface ExchangeRequest {
+	code?: unknown;
+	redirect_uri?: unknown;
+}
+
+interface GitHubTokenResponse {
+	access_token?: string;
+	scope?: string;
+	token_type?: string;
+	error?: string;
+	error_description?: string;
+}
+
+function pickAllowedOrigin(requestOrigin: string | undefined, configured: string): string | null {
+	const allowed = configured
+		.split(",")
+		.map((s) => s.trim())
+		.filter(Boolean);
+	if (allowed.length === 0) return null;
+	if (requestOrigin && allowed.includes(requestOrigin)) return requestOrigin;
+	return allowed[0];
+}
+
+function corsHeaders(origin: string | null): Record<string, string> {
+	const headers: Record<string, string> = {
+		"Access-Control-Allow-Methods": "POST, OPTIONS",
+		"Access-Control-Allow-Headers": "Content-Type",
+		"Access-Control-Max-Age": "86400",
+		Vary: "Origin",
+	};
+	if (origin) headers["Access-Control-Allow-Origin"] = origin;
+	return headers;
+}
+
+export default async (req: Request): Promise<Response> => {
+	const clientId = process.env.GITHUB_CLIENT_ID;
+	const clientSecret = process.env.GITHUB_CLIENT_SECRET;
+	const allowedOriginEnv = process.env.ALLOWED_ORIGIN ?? "";
+
+	const reqOrigin = req.headers.get("origin") ?? undefined;
+	const origin = pickAllowedOrigin(reqOrigin, allowedOriginEnv);
+	const cors = corsHeaders(origin);
+
+	if (req.method === "OPTIONS") {
+		return new Response(null, { status: 204, headers: cors });
+	}
+
+	if (req.method !== "POST") {
+		return new Response("Method Not Allowed", { status: 405, headers: cors });
+	}
+
+	if (!clientId || !clientSecret) {
+		return new Response(
+			JSON.stringify({ error: "server_misconfigured" }),
+			{ status: 500, headers: { ...cors, "Content-Type": "application/json" } },
+		);
+	}
+
+	let body: ExchangeRequest;
+	try {
+		body = (await req.json()) as ExchangeRequest;
+	} catch {
+		return new Response(
+			JSON.stringify({ error: "invalid_json" }),
+			{ status: 400, headers: { ...cors, "Content-Type": "application/json" } },
+		);
+	}
+
+	const code = typeof body.code === "string" ? body.code : null;
+	const redirectUri = typeof body.redirect_uri === "string" ? body.redirect_uri : undefined;
+	if (!code) {
+		return new Response(
+			JSON.stringify({ error: "missing_code" }),
+			{ status: 400, headers: { ...cors, "Content-Type": "application/json" } },
+		);
+	}
+
+	const ghRes = await fetch("https://github.com/login/oauth/access_token", {
+		method: "POST",
+		headers: {
+			Accept: "application/json",
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			client_id: clientId,
+			client_secret: clientSecret,
+			code,
+			...(redirectUri ? { redirect_uri: redirectUri } : {}),
+		}),
+	});
+
+	const data = (await ghRes.json()) as GitHubTokenResponse;
+
+	if (!ghRes.ok || data.error || !data.access_token) {
+		return new Response(
+			JSON.stringify({
+				error: data.error ?? "exchange_failed",
+				error_description: data.error_description,
+			}),
+			{ status: 400, headers: { ...cors, "Content-Type": "application/json" } },
+		);
+	}
+
+	return new Response(
+		JSON.stringify({
+			access_token: data.access_token,
+			scope: data.scope,
+			token_type: data.token_type,
+		}),
+		{ status: 200, headers: { ...cors, "Content-Type": "application/json" } },
+	);
+};


### PR DESCRIPTION
## Summary
- **Bug 1: deep-link routing** — Right-click "edit this event" in Pulseguide now actually lands on that event. Previously `?t=&lane=&index=` was parsed but mostly ignored: `t` was passed to a render-phase `seek()` that raced YouTube's `onReady`, while `lane` and `index` were never read. The editor opened at time zero regardless. Fix: a one-shot effect inside `Timeline` that runs once playback is ready — seeks (no autoplay), positions `scrollMs` so `t` lands at ~25% of the viewport, dispatches `selectAction(lane, index)`. `usePlayback` now exposes `playbackReady`, gated on the adapter's `waitForReady()`.
- **Bug 2: OAuth fails everywhere** — Sign-in had never worked in any environment. Empirically confirmed: `github.com/login/device/code` returns 404 to CORS preflights and ships no `Access-Control-Allow-Origin` header on actual responses. The browser kills the fetch before it reaches GitHub. Fix: switch to classic OAuth web flow with a tiny Netlify Function for the one step that must hit `github.com` (the code-for-token exchange). Browser redirect → GitHub → return with code → POST to `pulsemap-editor.netlify.app/oauth/token` → token. CSRF state nonce verified; pre-auth URL restored after exchange so deep links survive.

## Test plan
- [ ] Confirm Netlify env vars (`GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `ALLOWED_ORIGIN`) are set on `pulsemap-editor.netlify.app`.
- [ ] After Netlify deploy lands, `curl -i -X OPTIONS https://pulsemap-editor.netlify.app/oauth/token -H "Origin: https://hartphoenix.github.io" -H "Access-Control-Request-Method: POST"` returns 204 with `Access-Control-Allow-Origin: https://hartphoenix.github.io`.
- [ ] Click "Sign in with GitHub" in the deployed editor — redirects to GitHub authorize page, returns, username appears in header.
- [ ] Right-click a chord/word/lyric/section in Pulseguide → editor opens scrolled to that event with EditPanel populated.
- [ ] YouTube playback paused on arrival; pressing play starts from `t`.
- [ ] Submit a correction PR end-to-end on a throwaway map.
- [ ] Refresh editor on `?code=…&state=…` does not double-exchange (state consumed, URL cleaned).
- [ ] Sign out → sign back in → no stale state errors.

## Notes
- Netlify site is separate from the GitHub Pages-hosted editor (editor stays on Pages).
- Pre-existing TS errors on main (`diff.ts:28`, `useTimeline.ts:139`) untouched — not in scope.
- No Pulseguide changes needed; its call sites already pass `t/lane/index/source` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)