### PR TITLE
fix(editor): drop Authorization header on raw map fetches

### DIFF
--- a/editor/src/hooks/useMap.ts
+++ b/editor/src/hooks/useMap.ts
@@ -23,15 +23,14 @@ export function useMap(mapId: string | null) {
 
 		async function fetchMap() {
 			try {
-				const headers: Record<string, string> = {
-					Accept: "application/json",
-				};
-				const token = localStorage.getItem("pulsemap-gh-token");
-				if (token) {
-					headers.Authorization = `token ${token}`;
-				}
-
-				const response = await fetch(`${BASE_URL}/${mapId}.json`, { headers });
+				// raw.githubusercontent.com is fetched anonymously: adding an
+				// Authorization header makes it a non-simple request that
+				// triggers a CORS preflight raw.githubusercontent.com doesn't
+				// satisfy. The "5000/hr with auth" rate limit applies to
+				// api.github.com, not raw content.
+				const response = await fetch(`${BASE_URL}/${mapId}.json`, {
+					headers: { Accept: "application/json" },
+				});
 				if (!response.ok) {
 					throw new Error(
 						response.status === 404


### PR DESCRIPTION
## Summary
Follow-up to #39. Once OAuth started succeeding, every map fetch failed with `TypeError: Failed to fetch` because `useMap` attached an `Authorization: token …` header to its `raw.githubusercontent.com` request — a non-simple header that triggers a CORS preflight that GitHub's raw-content host doesn't satisfy. Removing the header.

The branch was dead code before #39 (no token ever existed in localStorage to take it). The "5000/hr with auth" rate limit it claimed to give us applies to `api.github.com`, not raw content, so removing it costs nothing.

## Test plan
- [ ] Signed-out user can load a map.
- [ ] Signed-in user can load a map (the regression).
- [ ] Right-click from Pulseguide → editor opens at the targeted event.
- [ ] Submit Correction PR flow still works (uses `api.github.com`, unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)