### PR TITLE
refactor(editor): submit corrections from a structural diff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,9 +273,13 @@ and GitHub PR submission.
   for inline text edit. Beat snapping (beat/half/quarter
   subdivision, Alt to bypass). Undo/redo (Cmd-Z/Shift-Z).
   Section split/merge. Arrow key nudge.
-- **State:** `EditorState` with `original`/`working` PulseMap,
-  `EditAction[]` history, undo/redo stacks. Array sort-by-`t`
-  invariant after every mutation.
+- **State:** `EditorState` with `original`/`working` PulseMap. Edits
+  mutate `working` directly. In-session undo/redo uses snapshot
+  stacks of `working` (capped, in-memory only — not persisted).
+  Submission semantics are derived from a structural diff between
+  `original` and `working`, not from a recorded action sequence,
+  so net-zero edits produce zero diff entries by definition.
+  Array sort-by-`t` invariant after every mutation.
 - **Persistence:** localStorage auto-save (500ms debounce), keyed
   by map ID + original hash. `beforeunload` warning when dirty.
   JSON export for backup.

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -97,7 +97,6 @@ function EditorContent({
 					dispatch({
 						type: "load-saved",
 						working: saved.working,
-						history: saved.history,
 						originalHash: hash,
 					});
 				} else {
@@ -110,7 +109,6 @@ function EditorContent({
 						dispatch({
 							type: "load-saved",
 							working: saved.working,
-							history: saved.history,
 							originalHash: hash,
 						});
 					}
@@ -120,7 +118,6 @@ function EditorContent({
 				dispatch({
 					type: "load-saved",
 					working: map,
-					history: [],
 					originalHash: hash,
 				});
 			}
@@ -131,9 +128,9 @@ function EditorContent({
 	useEffect(() => {
 		if (!state.originalHash) return;
 		if (state.dirty) {
-			saveEditorState(map.id, state.working, state.history, state.originalHash);
+			saveEditorState(map.id, state.working, state.originalHash);
 		}
-	}, [state.working, state.dirty, state.history, state.originalHash, map.id]);
+	}, [state.working, state.dirty, state.originalHash, map.id]);
 
 	// beforeunload warning when dirty
 	useEffect(() => {
@@ -188,8 +185,8 @@ function EditorContent({
 
 	const handleSave = useCallback(() => {
 		if (!state.dirty || !state.originalHash) return;
-		saveEditorState(map.id, state.working, state.history, state.originalHash);
-	}, [state.dirty, state.working, state.history, state.originalHash, map.id]);
+		saveEditorState(map.id, state.working, state.originalHash);
+	}, [state.dirty, state.working, state.originalHash, map.id]);
 
 	useKeyboardShortcuts({
 		onPlayPause: handlePlayPause,
@@ -215,7 +212,7 @@ function EditorContent({
 					</div>
 				</div>
 				<div style={styles.headerRight}>
-					<DirtyIndicator dirty={state.dirty} editCount={state.history.length} />
+					<DirtyIndicator dirty={state.dirty} />
 					{state.dirty && (
 						<button
 							type="button"
@@ -226,7 +223,6 @@ function EditorContent({
 									dispatch({
 										type: "load-saved",
 										working: map,
-										history: [],
 										originalHash: state.originalHash,
 									});
 								}
@@ -286,8 +282,8 @@ function EditorContent({
 
 			{showSubmitFlow && ghToken && (
 				<SubmitFlow
-					map={workingMap}
-					history={state.history}
+					original={state.original}
+					working={workingMap}
 					token={ghToken}
 					playbackAvailable={playbackAvailable}
 					errorCount={errorCount}
@@ -302,7 +298,6 @@ function EditorContent({
 					{workingMap.words ? ` | ${workingMap.words.length} words` : ""}
 					{workingMap.chords ? ` | ${workingMap.chords.length} chords` : ""}
 					{workingMap.beats ? ` | ${workingMap.beats.length} beats` : ""}
-					{state.history.length > 0 ? ` | ${state.history.length} edits` : ""}
 				</code>
 			</div>
 		</>

--- a/editor/src/components/DiffReview.tsx
+++ b/editor/src/components/DiffReview.tsx
@@ -1,8 +1,8 @@
 import { type CSSProperties, useCallback } from "react";
-import type { DiffChange } from "../github/diff";
+import { type DiffEntry, describeEntry, fieldCountsByLane } from "../github/diff";
 
 interface DiffReviewProps {
-	changes: DiffChange[];
+	entries: DiffEntry[];
 	checkedIndices: Set<number>;
 	onToggle: (index: number) => void;
 	playbackAvailable: boolean;
@@ -10,21 +10,16 @@ interface DiffReviewProps {
 }
 
 export function DiffReview({
-	changes,
+	entries,
 	checkedIndices,
 	onToggle,
 	playbackAvailable,
 	errorCount,
 }: DiffReviewProps) {
-	// Per-field summary
-	const fieldCounts: Record<string, number> = {};
-	for (const c of changes) {
-		if (checkedIndices.has(changes.indexOf(c))) {
-			fieldCounts[c.lane] = (fieldCounts[c.lane] || 0) + 1;
-		}
-	}
-	const fieldSummary = Object.entries(fieldCounts)
-		.map(([field, count]) => `${count} ${field}`)
+	const selectedEntries = entries.filter((_, i) => checkedIndices.has(i));
+	const counts = fieldCountsByLane(selectedEntries);
+	const fieldSummary = Object.entries(counts)
+		.map(([lane, n]) => `${n} ${lane}`)
 		.join(", ");
 
 	const handleToggle = useCallback((i: number) => () => onToggle(i), [onToggle]);
@@ -33,7 +28,7 @@ export function DiffReview({
 		<div style={styles.container}>
 			<div style={styles.header}>
 				<span style={styles.summary}>
-					{checkedIndices.size} of {changes.length} changes selected
+					{checkedIndices.size} of {entries.length} changes selected
 					{fieldSummary && ` (${fieldSummary})`}
 				</span>
 
@@ -51,20 +46,20 @@ export function DiffReview({
 			)}
 
 			<div style={styles.changeList}>
-				{changes.map((change, i) => (
-					<label key={`${change.lane}-${change.action.type}-${i}`} style={styles.changeRow}>
+				{entries.map((entry, i) => (
+					<label key={`${entry.lane}-${entry.kind}-${entry.index}-${i}`} style={styles.changeRow}>
 						<input
 							type="checkbox"
 							checked={checkedIndices.has(i)}
 							onChange={handleToggle(i)}
 							style={styles.checkbox}
 						/>
-						<span style={styles.changeText}>{change.description}</span>
+						<span style={styles.changeText}>{describeEntry(entry)}</span>
 					</label>
 				))}
 			</div>
 
-			{changes.length === 0 && <div style={styles.empty}>No changes to review.</div>}
+			{entries.length === 0 && <div style={styles.empty}>No changes to review.</div>}
 		</div>
 	);
 }

--- a/editor/src/components/DirtyIndicator.tsx
+++ b/editor/src/components/DirtyIndicator.tsx
@@ -2,16 +2,15 @@ import type { CSSProperties } from "react";
 
 interface DirtyIndicatorProps {
 	dirty: boolean;
-	editCount: number;
 }
 
-export function DirtyIndicator({ dirty, editCount }: DirtyIndicatorProps) {
+export function DirtyIndicator({ dirty }: DirtyIndicatorProps) {
 	if (!dirty) return null;
 
 	return (
 		<span style={styles.indicator}>
 			<span style={styles.dot} />
-			Unsaved ({editCount} edit{editCount !== 1 ? "s" : ""})
+			Unsaved
 		</span>
 	);
 }

--- a/editor/src/components/SubmitFlow.tsx
+++ b/editor/src/components/SubmitFlow.tsx
@@ -1,17 +1,15 @@
 import type { PulseMap } from "pulsemap/schema";
 import { type CSSProperties, useCallback, useMemo, useState } from "react";
-import type { SubmitStep } from "../github/api";
-import { submitCorrection } from "../github/api";
-import { generateDiffSummary } from "../github/diff";
-import type { EditAction } from "../state/types";
+import { type SubmitStep, submitCorrection } from "../github/api";
+import { applyDiffEntries, diffMaps } from "../github/diff";
 import { DiffReview } from "./DiffReview";
 import { ProgressIndicator } from "./ProgressIndicator";
 
 type FlowStep = "review" | "submitting" | "done" | "error";
 
 interface SubmitFlowProps {
-	map: PulseMap;
-	history: EditAction[];
+	original: PulseMap;
+	working: PulseMap;
 	token: string;
 	playbackAvailable: boolean;
 	errorCount: number;
@@ -19,8 +17,8 @@ interface SubmitFlowProps {
 }
 
 export function SubmitFlow({
-	map,
-	history,
+	original,
+	working,
 	token,
 	playbackAvailable,
 	errorCount,
@@ -31,10 +29,9 @@ export function SubmitFlow({
 	const [prUrl, setPrUrl] = useState<string | undefined>();
 	const [submitError, setSubmitError] = useState<string | undefined>();
 
-	// All changes checked by default
-	const diffResult = useMemo(() => generateDiffSummary(history), [history]);
+	const entries = useMemo(() => diffMaps(original, working), [original, working]);
 	const [checkedIndices, setCheckedIndices] = useState<Set<number>>(
-		() => new Set(diffResult.changes.map((_, i) => i)),
+		() => new Set(entries.map((_, i) => i)),
 	);
 
 	const handleToggle = useCallback((index: number) => {
@@ -46,25 +43,25 @@ export function SubmitFlow({
 		});
 	}, []);
 
-	// Filter history to only checked changes
-	const selectedHistory = useMemo(
-		() => history.filter((_, i) => checkedIndices.has(i)),
-		[history, checkedIndices],
+	const selectedEntries = useMemo(
+		() => entries.filter((_, i) => checkedIndices.has(i)),
+		[entries, checkedIndices],
 	);
 
-	const canSubmit = errorCount === 0 && selectedHistory.length > 0 && flowStep === "review";
+	const canSubmit = errorCount === 0 && selectedEntries.length > 0 && flowStep === "review";
 
 	const handleSubmit = useCallback(async () => {
 		setFlowStep("submitting");
 		setSubmitError(undefined);
 
 		try {
+			const submittedMap = applyDiffEntries(original, selectedEntries);
 			const result = await submitCorrection(
 				{
 					token,
-					mapId: map.id,
-					map,
-					history: selectedHistory,
+					mapId: original.id,
+					map: submittedMap,
+					entries: selectedEntries,
 					playbackAvailable,
 					source: "PulseMap Editor",
 				},
@@ -76,7 +73,7 @@ export function SubmitFlow({
 			setSubmitError(err instanceof Error ? err.message : "Submission failed");
 			setFlowStep("error");
 		}
-	}, [token, map, selectedHistory, playbackAvailable]);
+	}, [token, original, selectedEntries, playbackAvailable]);
 
 	return (
 		<div style={styles.overlay} onClick={onClose}>
@@ -92,7 +89,7 @@ export function SubmitFlow({
 					{(flowStep === "review" || flowStep === "error") && (
 						<>
 							<DiffReview
-								changes={diffResult.changes}
+								entries={entries}
 								checkedIndices={checkedIndices}
 								onToggle={handleToggle}
 								playbackAvailable={playbackAvailable}

--- a/editor/src/github/api.ts
+++ b/editor/src/github/api.ts
@@ -4,8 +4,7 @@
  * Flow: fork repo -> create branch -> commit map JSON -> open PR.
  */
 import type { PulseMap } from "pulsemap/schema";
-import type { EditAction } from "../state/types";
-import { generateDiffSummary } from "./diff";
+import { type DiffEntry, describeEntry, fieldCountsByLane, laneSummary } from "./diff";
 
 const UPSTREAM_OWNER = "hartphoenix";
 const UPSTREAM_REPO = "pulsemap";
@@ -15,7 +14,7 @@ interface SubmitCorrectionParams {
 	token: string;
 	mapId: string;
 	map: PulseMap;
-	history: EditAction[];
+	entries: DiffEntry[];
 	playbackAvailable: boolean;
 	source?: string;
 }
@@ -25,9 +24,7 @@ interface SubmitCorrectionResult {
 	prNumber: number;
 }
 
-/** Callback for progress reporting during submission. */
 export type ProgressCallback = (step: SubmitStep) => void;
-
 export type SubmitStep = "forking" | "branching" | "committing" | "opening-pr" | "done";
 
 async function ghFetch(path: string, token: string, options: RequestInit = {}): Promise<Response> {
@@ -56,24 +53,24 @@ async function ghJson<T>(path: string, token: string, options: RequestInit = {})
 function buildPrBody(params: {
 	map: PulseMap;
 	mapId: string;
-	history: EditAction[];
+	entries: DiffEntry[];
 	playbackAvailable: boolean;
 	source?: string;
 }): string {
-	const { map, mapId, history, playbackAvailable, source } = params;
+	const { map, mapId, entries, playbackAvailable, source } = params;
 	const meta = map.metadata;
 	const title = meta?.title ?? mapId;
 	const artist = meta?.artist ?? "Unknown";
-	const { summary, changes, fieldCounts } = generateDiffSummary(history);
 
-	const changeLines = changes.map((c) => `- ${c.description}`).join("\n");
+	const summary = laneSummary(entries);
+	const changeLines = entries.map((e) => `- ${describeEntry(e)}`).join("\n");
 
 	const playbackNote = !playbackAvailable
 		? "\n**Note:** Edited without audio playback available.\n"
 		: "";
 
 	const correctionMeta = JSON.stringify({
-		fields: fieldCounts,
+		fields: fieldCountsByLane(entries),
 		playback_available: playbackAvailable,
 	});
 
@@ -82,15 +79,15 @@ function buildPrBody(params: {
 		`**Map ID:** \`${mapId}\``,
 		`**Submitted via:** ${source || "PulseMap Editor"}`,
 		playbackNote,
-		`### Changes (${history.length} edit${history.length !== 1 ? "s" : ""})`,
-		`${summary}`,
+		`### Changes (${entries.length} ${entries.length === 1 ? "edit" : "edits"})`,
+		summary,
 		"",
 		changeLines,
 		"",
-		"<details><summary>Full edit history</summary>",
+		"<details><summary>Structural diff</summary>",
 		"",
 		"```json",
-		JSON.stringify(history, null, 2),
+		JSON.stringify(entries, null, 2),
 		"```",
 		"",
 		"</details>",
@@ -105,23 +102,19 @@ export async function submitCorrection(
 	params: SubmitCorrectionParams,
 	onProgress?: ProgressCallback,
 ): Promise<SubmitCorrectionResult> {
-	const { token, mapId, map, history, playbackAvailable, source } = params;
+	const { token, mapId, map, entries, playbackAvailable, source } = params;
 
-	// 1. Get authenticated user
 	const user = await ghJson<{ login: string }>("/user", token);
 	const username = user.login;
 
-	// 2. Fork (idempotent — returns existing fork if already forked)
 	onProgress?.("forking");
 	await ghJson<{ full_name: string }>(`/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/forks`, token, {
 		method: "POST",
 		body: JSON.stringify({}),
 	});
 
-	// Brief pause to let GitHub propagate the fork
 	await new Promise((r) => setTimeout(r, 2000));
 
-	// 3. Get main branch SHA from the fork
 	onProgress?.("branching");
 	const mainRef = await ghJson<{ object: { sha: string } }>(
 		`/repos/${username}/${UPSTREAM_REPO}/git/ref/heads/main`,
@@ -129,7 +122,6 @@ export async function submitCorrection(
 	);
 	const mainSha = mainRef.object.sha;
 
-	// 4. Create branch
 	const timestamp = Date.now();
 	const branchName = `correction/${mapId}-${timestamp}`;
 	await ghJson<{ ref: string }>(`/repos/${username}/${UPSTREAM_REPO}/git/refs`, token, {
@@ -140,7 +132,6 @@ export async function submitCorrection(
 		}),
 	});
 
-	// 5. Get existing file SHA (for the update)
 	onProgress?.("committing");
 	const filePath = `maps/${mapId}.json`;
 	let fileSha: string | undefined;
@@ -155,7 +146,6 @@ export async function submitCorrection(
 		// File doesn't exist yet — new map
 	}
 
-	// 6. Commit the map JSON
 	const content = btoa(unescape(encodeURIComponent(JSON.stringify(map, null, 2))));
 	await ghJson<{ commit: { sha: string } }>(
 		`/repos/${username}/${UPSTREAM_REPO}/contents/${filePath}`,
@@ -171,9 +161,8 @@ export async function submitCorrection(
 		},
 	);
 
-	// 7. Create PR against upstream
 	onProgress?.("opening-pr");
-	const prBody = buildPrBody({ map, mapId, history, playbackAvailable, source });
+	const prBody = buildPrBody({ map, mapId, entries, playbackAvailable, source });
 	const meta = map.metadata;
 	const prTitle = `fix(map): ${meta?.title ?? mapId} corrections`;
 

--- a/editor/src/github/diff.ts
+++ b/editor/src/github/diff.ts
@@ -1,96 +1,274 @@
 /**
- * Generate human-readable diff summaries from EditAction[] history.
+ * Structural diff between an original PulseMap and the editor's working map.
+ *
+ * Produces a flat list of DiffEntry rows: per-field changes on matched
+ * events, plus inserts and deletes for events with no counterpart.
+ *
+ * Each entry is independently applicable to `original` to reconstruct
+ * the working state — this is how selective submission works (apply
+ * only the rows the user kept checked).
  */
-import type { EditAction, EditableLane } from "../state/types";
 
-export interface DiffChange {
-	/** Human-readable description of the change */
-	description: string;
-	/** Which lane was affected */
-	lane: EditableLane;
-	/** The original EditAction */
-	action: EditAction;
+import type { ChordEvent, LyricLine, PulseMap, Section, WordEvent } from "pulsemap/schema";
+import type { EditableLane } from "../state/types";
+
+export type DiffEntry =
+	| {
+			kind: "field";
+			lane: EditableLane;
+			/** Index in `original` (post-match). */
+			index: number;
+			field: string;
+			before: unknown;
+			after: unknown;
+	  }
+	| {
+			kind: "insert";
+			lane: EditableLane;
+			/** Position in `working` where the new event sits. */
+			index: number;
+			value: unknown;
+	  }
+	| {
+			kind: "delete";
+			lane: EditableLane;
+			/** Position in `original` of the removed event. */
+			index: number;
+			value: unknown;
+	  };
+
+const EDITABLE_LANES: readonly EditableLane[] = ["chords", "words", "lyrics", "sections"] as const;
+
+type LaneEvent = ChordEvent | WordEvent | LyricLine | Section;
+
+interface MatchResult {
+	pairs: Array<{ originalIndex: number; workingIndex: number }>;
+	originalUnmatched: number[];
+	workingUnmatched: number[];
 }
 
-export interface DiffSummary {
-	/** One-line summary like "3 chords modified, 2 sections added" */
-	summary: string;
-	/** Individual human-readable changes */
-	changes: DiffChange[];
-	/** Count of changes per field, for pulsemap-correction metadata */
-	fieldCounts: Record<string, number>;
+/**
+ * Score how plausibly two events represent "the same item, edited."
+ * Higher means more likely the same. A pair below MATCH_THRESHOLD is
+ * treated as unrelated (insert+delete rather than edit).
+ */
+function similarity(a: LaneEvent, b: LaneEvent, lane: EditableLane): number {
+	let score = 0;
+	if (a.t === b.t) score += 100;
+	else if (Math.abs(a.t - b.t) < 1000) score += 30;
+
+	if (lane === "chords") {
+		const ca = a as ChordEvent;
+		const cb = b as ChordEvent;
+		if (ca.chord === cb.chord) score += 80;
+	} else if (lane === "words" || lane === "lyrics") {
+		const ta = (a as WordEvent | LyricLine).text;
+		const tb = (b as WordEvent | LyricLine).text;
+		if (ta === tb) score += 80;
+		else if (ta && tb && ta.toLowerCase() === tb.toLowerCase()) score += 40;
+	} else if (lane === "sections") {
+		const sa = a as Section;
+		const sb = b as Section;
+		if (sa.type === sb.type) score += 50;
+		if (sa.label === sb.label) score += 30;
+	}
+	return score;
 }
 
-function formatMs(ms: number): string {
-	return `${(ms / 1000).toFixed(1)}s`;
+const MATCH_THRESHOLD = 50;
+
+/** Greedy best-fit pairing between two arrays. */
+function matchEvents(before: LaneEvent[], after: LaneEvent[], lane: EditableLane): MatchResult {
+	const candidates: Array<{ i: number; j: number; score: number }> = [];
+	for (let i = 0; i < before.length; i++) {
+		for (let j = 0; j < after.length; j++) {
+			const s = similarity(before[i], after[j], lane);
+			if (s >= MATCH_THRESHOLD) candidates.push({ i, j, score: s });
+		}
+	}
+	candidates.sort((a, b) => b.score - a.score || a.i - b.i || a.j - b.j);
+
+	const claimedI = new Set<number>();
+	const claimedJ = new Set<number>();
+	const pairs: MatchResult["pairs"] = [];
+
+	for (const c of candidates) {
+		if (claimedI.has(c.i) || claimedJ.has(c.j)) continue;
+		pairs.push({ originalIndex: c.i, workingIndex: c.j });
+		claimedI.add(c.i);
+		claimedJ.add(c.j);
+	}
+
+	const originalUnmatched: number[] = [];
+	for (let i = 0; i < before.length; i++) if (!claimedI.has(i)) originalUnmatched.push(i);
+	const workingUnmatched: number[] = [];
+	for (let j = 0; j < after.length; j++) if (!claimedJ.has(j)) workingUnmatched.push(j);
+
+	return { pairs, originalUnmatched, workingUnmatched };
 }
 
-function describeAction(action: EditAction): string {
-	switch (action.type) {
-		case "move":
-			return (
-				`${action.lane}[${action.index}]: ` +
-				`Repositioned ${formatMs(action.before.t)} -> ${formatMs(action.after.t)}`
-			);
-		case "resize":
-			return (
-				`${action.lane}[${action.index}]: ` +
-				`End changed ${action.before.end != null ? `${action.before.end}ms` : "none"} -> ` +
-				`${action.after.end != null ? `${action.after.end}ms` : "none"}`
-			);
-		case "edit-text":
-			return (
-				`${action.lane}[${action.index}]: ` +
-				`Changed "${action.before}" -> "${action.after}" at ${action.field}`
-			);
-		case "edit-field":
-			return (
-				`${action.lane}[${action.index}]: ` +
-				`${action.field} changed from ${JSON.stringify(action.before)} ` +
-				`to ${JSON.stringify(action.after)}`
-			);
-		case "insert":
-			return `${action.lane}: Added ${describeInsertedValue(action)} at index ${action.index}`;
-		case "delete":
-			return `${action.lane}[${action.index}]: Deleted ${describeDeletedValue(action)}`;
+/** Field names to compare per lane. */
+const FIELDS_BY_LANE: Record<EditableLane, readonly string[]> = {
+	chords: ["t", "end", "chord"],
+	words: ["t", "end", "text"],
+	lyrics: ["t", "end", "text"],
+	sections: ["t", "end", "type", "label"],
+};
+
+function fieldDiffs(
+	lane: EditableLane,
+	originalIndex: number,
+	a: LaneEvent,
+	b: LaneEvent,
+): DiffEntry[] {
+	const out: DiffEntry[] = [];
+	for (const field of FIELDS_BY_LANE[lane]) {
+		const av = (a as Record<string, unknown>)[field];
+		const bv = (b as Record<string, unknown>)[field];
+		if (av === bv) continue;
+		out.push({
+			kind: "field",
+			lane,
+			index: originalIndex,
+			field,
+			before: av,
+			after: bv,
+		});
+	}
+	return out;
+}
+
+function laneArray(map: PulseMap, lane: EditableLane): LaneEvent[] {
+	switch (lane) {
+		case "chords":
+			return (map.chords ?? []) as LaneEvent[];
+		case "words":
+			return (map.words ?? []) as LaneEvent[];
+		case "lyrics":
+			return (map.lyrics ?? []) as LaneEvent[];
+		case "sections":
+			return (map.sections ?? []) as LaneEvent[];
 	}
 }
 
-function describeInsertedValue(action: EditAction & { type: "insert" }): string {
-	const val = action.value as Record<string, unknown>;
-	if (action.lane === "chords" && val.chord) return `"${val.chord}"`;
-	if (action.lane === "sections" && val.label) return `"${val.label}"`;
-	if ((action.lane === "words" || action.lane === "lyrics") && val.text) return `"${val.text}"`;
-	return "item";
+/** Compute the structural diff between original and working maps. */
+export function diffMaps(original: PulseMap, working: PulseMap): DiffEntry[] {
+	const entries: DiffEntry[] = [];
+	for (const lane of EDITABLE_LANES) {
+		const before = laneArray(original, lane);
+		const after = laneArray(working, lane);
+		const { pairs, originalUnmatched, workingUnmatched } = matchEvents(before, after, lane);
+
+		for (const { originalIndex, workingIndex } of pairs) {
+			entries.push(...fieldDiffs(lane, originalIndex, before[originalIndex], after[workingIndex]));
+		}
+		for (const i of originalUnmatched) {
+			entries.push({ kind: "delete", lane, index: i, value: before[i] });
+		}
+		for (const j of workingUnmatched) {
+			entries.push({ kind: "insert", lane, index: j, value: after[j] });
+		}
+	}
+	return entries;
 }
 
-function describeDeletedValue(action: EditAction & { type: "delete" }): string {
-	const val = action.value as Record<string, unknown>;
-	if (action.lane === "chords" && val.chord) return `"${val.chord}"`;
-	if (action.lane === "sections" && val.label) return `"${val.label}"`;
-	if ((action.lane === "words" || action.lane === "lyrics") && val.text) return `"${val.text}"`;
-	return "item";
+/**
+ * Apply a subset of diff entries to `original` to produce a new PulseMap.
+ * Entries reference indices in `original` (for field/delete) or in
+ * `working` (for insert); we apply in an order that keeps both index
+ * spaces stable: field updates first (in original-index order), then
+ * deletes (descending), then inserts (ascending into the resulting
+ * array). Each lane's array is re-sorted by `t` after edits.
+ */
+export function applyDiffEntries(original: PulseMap, entries: DiffEntry[]): PulseMap {
+	const out = JSON.parse(JSON.stringify(original)) as PulseMap;
+
+	for (const lane of EDITABLE_LANES) {
+		const laneEntries = entries.filter((e) => e.lane === lane);
+		if (laneEntries.length === 0) continue;
+
+		const arr = laneArray(out, lane);
+
+		for (const e of laneEntries) {
+			if (e.kind === "field") {
+				const target = arr[e.index] as Record<string, unknown>;
+				if (target == null) continue;
+				if (e.after === undefined) delete target[e.field];
+				else target[e.field] = e.after;
+			}
+		}
+
+		const deletes = laneEntries
+			.filter((e): e is Extract<DiffEntry, { kind: "delete" }> => e.kind === "delete")
+			.sort((a, b) => b.index - a.index);
+		for (const e of deletes) arr.splice(e.index, 1);
+
+		const inserts = laneEntries
+			.filter((e): e is Extract<DiffEntry, { kind: "insert" }> => e.kind === "insert")
+			.sort((a, b) => a.index - b.index);
+		for (const e of inserts) arr.push(JSON.parse(JSON.stringify(e.value)));
+
+		(arr as { t: number }[]).sort((a, b) => a.t - b.t);
+		(out as Record<string, unknown>)[lane] = arr;
+	}
+
+	return out;
 }
 
-export function generateDiffSummary(history: EditAction[]): DiffSummary {
-	const changes: DiffChange[] = history.map((action) => ({
-		description: describeAction(action),
-		lane: action.lane,
-		action,
-	}));
+function formatValue(v: unknown): string {
+	if (v === undefined || v === null) return "—";
+	if (typeof v === "string") return `"${v}"`;
+	if (typeof v === "number") return Number.isInteger(v) ? String(v) : v.toFixed(2);
+	return JSON.stringify(v);
+}
 
-	// Count changes per lane
-	const fieldCounts: Record<string, number> = {};
-	for (const action of history) {
-		fieldCounts[action.lane] = (fieldCounts[action.lane] || 0) + 1;
+function formatTimeMs(ms: unknown): string {
+	if (typeof ms !== "number") return formatValue(ms);
+	return `${(ms / 1000).toFixed(2)}s`;
+}
+
+export function describeEntry(entry: DiffEntry): string {
+	switch (entry.kind) {
+		case "field": {
+			const { lane, index, field, before, after } = entry;
+			const fmt = field === "t" || field === "end" ? formatTimeMs : formatValue;
+			return `${lane}[${index}].${field}: ${fmt(before)} → ${fmt(after)}`;
+		}
+		case "insert": {
+			const v = entry.value as Record<string, unknown>;
+			const label =
+				entry.lane === "chords" && typeof v.chord === "string"
+					? `"${v.chord}"`
+					: (entry.lane === "words" || entry.lane === "lyrics") && typeof v.text === "string"
+						? `"${v.text}"`
+						: entry.lane === "sections" && typeof v.label === "string"
+							? `"${v.label}"`
+							: "item";
+			return `${entry.lane}: + ${label} at ${formatTimeMs(v.t)}`;
+		}
+		case "delete": {
+			const v = entry.value as Record<string, unknown>;
+			const label =
+				entry.lane === "chords" && typeof v.chord === "string"
+					? `"${v.chord}"`
+					: (entry.lane === "words" || entry.lane === "lyrics") && typeof v.text === "string"
+						? `"${v.text}"`
+						: entry.lane === "sections" && typeof v.label === "string"
+							? `"${v.label}"`
+							: "item";
+			return `${entry.lane}[${entry.index}]: − ${label} at ${formatTimeMs(v.t)}`;
+		}
 	}
+}
 
-	// Build summary string
-	const parts: string[] = [];
-	for (const [field, count] of Object.entries(fieldCounts)) {
-		parts.push(`${count} ${field}`);
-	}
-	const summary = parts.length > 0 ? parts.join(", ") : "no changes";
+export function fieldCountsByLane(entries: DiffEntry[]): Record<string, number> {
+	const counts: Record<string, number> = {};
+	for (const e of entries) counts[e.lane] = (counts[e.lane] ?? 0) + 1;
+	return counts;
+}
 
-	return { summary, changes, fieldCounts };
+export function laneSummary(entries: DiffEntry[]): string {
+	const counts = fieldCountsByLane(entries);
+	const parts = Object.entries(counts).map(([lane, n]) => `${n} ${lane}`);
+	return parts.length > 0 ? parts.join(", ") : "no changes";
 }

--- a/editor/src/persistence/storage.ts
+++ b/editor/src/persistence/storage.ts
@@ -2,16 +2,13 @@
  * localStorage persistence for editor state.
  *
  * Key format: `pulsemap-edit:${mapId}`
- * Payload: working map, edit history, save timestamp, and
- * a hash of the original (upstream) map so we can detect
- * upstream changes on reload.
+ * Payload: working map plus a hash of the original (upstream) map so
+ * we can detect upstream changes on reload.
  */
 import type { PulseMap } from "pulsemap/schema";
-import type { EditAction } from "../state/types";
 
 export interface SavedEditorState {
 	working: PulseMap;
-	history: EditAction[];
 	savedAt: number;
 	originalHash: string;
 }
@@ -25,12 +22,13 @@ export function loadEditorState(mapId: string): SavedEditorState | null {
 	try {
 		const raw = localStorage.getItem(storageKey(mapId));
 		if (!raw) return null;
-		const parsed = JSON.parse(raw) as SavedEditorState;
-		// Basic shape check
-		if (!parsed.working || !Array.isArray(parsed.history) || !parsed.originalHash) {
-			return null;
-		}
-		return parsed;
+		const parsed = JSON.parse(raw) as Partial<SavedEditorState>;
+		if (!parsed.working || !parsed.originalHash) return null;
+		return {
+			working: parsed.working,
+			savedAt: parsed.savedAt ?? 0,
+			originalHash: parsed.originalHash,
+		};
 	} catch {
 		return null;
 	}
@@ -45,23 +43,15 @@ export function clearEditorState(mapId: string): void {
 	}
 }
 
-// -- Debounced save -----------------------------------------------------------
-
 let saveTimer: ReturnType<typeof setTimeout> | null = null;
 
 /** Debounced (500ms) write of editor state to localStorage. */
-export function saveEditorState(
-	mapId: string,
-	working: PulseMap,
-	history: EditAction[],
-	originalHash: string,
-): void {
+export function saveEditorState(mapId: string, working: PulseMap, originalHash: string): void {
 	if (saveTimer) clearTimeout(saveTimer);
 	saveTimer = setTimeout(() => {
 		try {
 			const payload: SavedEditorState = {
 				working,
-				history,
 				savedAt: Date.now(),
 				originalHash,
 			};

--- a/editor/src/state/reducer.ts
+++ b/editor/src/state/reducer.ts
@@ -1,12 +1,18 @@
 import type { PulseMap } from "pulsemap/schema";
 import type { EditAction, EditableLane, EditorDispatchAction, EditorState } from "./types";
 
+const UNDO_LIMIT = 100;
+
 /** Deep clone a PulseMap (JSON-safe) */
 function cloneMap(map: PulseMap): PulseMap {
 	return JSON.parse(JSON.stringify(map));
 }
 
-/** Get the mutable array for a lane from a PulseMap, creating it if absent */
+/** Stable JSON for equality checks. Stable enough — both maps are produced by us. */
+function stableEqual(a: PulseMap, b: PulseMap): boolean {
+	return JSON.stringify(a) === JSON.stringify(b);
+}
+
 function getLaneArray(map: PulseMap, lane: EditableLane): unknown[] {
 	if (!map[lane]) {
 		(map as Record<string, unknown>)[lane] = [];
@@ -14,132 +20,60 @@ function getLaneArray(map: PulseMap, lane: EditableLane): unknown[] {
 	return map[lane] as unknown[];
 }
 
-/** Sort an array of timed events by t */
 function sortByT(arr: unknown[]): void {
 	arr.sort((a, b) => (a as { t: number }).t - (b as { t: number }).t);
 }
 
-/**
- * Find the new index of an event after sorting, given its old `t` value
- * and the new `t` value (for moves) or unchanged `t` (for other actions).
- */
 function findIndexByT(arr: unknown[], t: number, startHint: number): number {
-	// Exact match first
 	for (let i = 0; i < arr.length; i++) {
 		if ((arr[i] as { t: number }).t === t) return i;
 	}
-	// Fallback: closest to hint
-	return Math.min(startHint, arr.length - 1);
+	return Math.min(Math.max(startHint, 0), arr.length - 1);
 }
 
-/** Apply the "after" side of an action to a working map */
-function applyForward(map: PulseMap, action: EditAction): void {
-	const arr = getLaneArray(map, action.lane);
+/** Mutate `working` in place to apply one edit action. */
+function applyEdit(working: PulseMap, action: EditAction): void {
+	const arr = getLaneArray(working, action.lane);
 
 	switch (action.type) {
 		case "move": {
-			const event = arr[action.index] as { t: number };
-			// Preserve duration if the event has an end
-			const asEnd = event as { t: number; end?: number };
-			if (asEnd.end != null) {
-				const duration = asEnd.end - asEnd.t;
-				asEnd.end = action.after.t + duration;
-			}
-			event.t = action.after.t;
-			break;
-		}
-		case "resize": {
-			const event = arr[action.index] as Record<string, unknown>;
-			if (action.after.end !== undefined) {
-				event.end = action.after.end;
-			} else {
-				delete event.end;
-			}
-			break;
-		}
-		case "resize-start": {
-			const event = arr[action.index] as { t: number };
-			event.t = action.after.t;
-			break;
-		}
-		case "edit-text": {
-			const event = arr[action.index] as Record<string, unknown>;
-			event[action.field] = action.after;
-			break;
-		}
-		case "edit-field": {
-			const event = arr[action.index] as Record<string, unknown>;
-			event[action.field] = action.after;
-			break;
-		}
-		case "insert": {
-			arr.splice(action.index, 0, JSON.parse(JSON.stringify(action.value)));
-			break;
-		}
-		case "delete": {
-			arr.splice(action.index, 1);
-			break;
-		}
-	}
-}
-
-/** Apply the "before" side of an action (undo) to a working map */
-function applyBackward(map: PulseMap, action: EditAction): void {
-	const arr = getLaneArray(map, action.lane);
-
-	switch (action.type) {
-		case "move": {
-			// We need to find the event at the "after" position and move it back
-			const idx = findIndexByT(arr, action.after.t, action.index);
-			const event = arr[idx] as { t: number; end?: number };
+			const event = arr[action.index] as { t: number; end?: number };
 			if (event.end != null) {
 				const duration = event.end - event.t;
-				event.end = action.before.t + duration;
+				event.end = action.after.t + duration;
 			}
-			event.t = action.before.t;
+			event.t = action.after.t;
 			break;
 		}
 		case "resize": {
 			const event = arr[action.index] as Record<string, unknown>;
-			if (action.before.end !== undefined) {
-				event.end = action.before.end;
-			} else {
-				delete event.end;
-			}
+			if (action.after.end !== undefined) event.end = action.after.end;
+			else delete event.end;
 			break;
 		}
 		case "resize-start": {
-			const idx = findIndexByT(arr, action.after.t, action.index);
-			const event = arr[idx] as { t: number };
-			event.t = action.before.t;
+			const event = arr[action.index] as { t: number };
+			event.t = action.after.t;
 			break;
 		}
-		case "edit-text": {
-			const event = arr[action.index] as Record<string, unknown>;
-			event[action.field] = action.before;
-			break;
-		}
+		case "edit-text":
 		case "edit-field": {
 			const event = arr[action.index] as Record<string, unknown>;
-			event[action.field] = action.before;
+			event[action.field] = action.after;
 			break;
 		}
-		case "insert": {
-			// Undo insert = delete
-			arr.splice(action.index, 1);
-			break;
-		}
-		case "delete": {
-			// Undo delete = insert
+		case "insert":
 			arr.splice(action.index, 0, JSON.parse(JSON.stringify(action.value)));
 			break;
-		}
+		case "delete":
+			arr.splice(action.index, 1);
+			break;
 	}
 }
 
 /**
- * After mutating the lane array, re-sort by t and update the selection
- * index to follow the event that was at `oldIndex` with `targetT`.
+ * After mutating an array, re-sort by t and update the selection index
+ * to follow the event that was at oldIndex with the given target t.
  */
 function resortAndTrackSelection(
 	state: EditorState,
@@ -149,58 +83,56 @@ function resortAndTrackSelection(
 ): EditorState {
 	const arr = getLaneArray(state.working, lane);
 	sortByT(arr);
-
-	// Update selection to track the moved event
 	if (state.selection?.lane === lane) {
 		const newIdx = findIndexByT(arr, targetT, oldIndex);
-		return {
-			...state,
-			selection: { lane, index: newIdx },
-		};
+		return { ...state, selection: { lane, index: newIdx } };
 	}
 	return state;
 }
 
 export function editorReducer(state: EditorState, dispatch: EditorDispatchAction): EditorState {
 	switch (dispatch.type) {
-		case "load": {
+		case "load":
 			return {
 				original: cloneMap(dispatch.map),
 				working: cloneMap(dispatch.map),
-				history: [],
+				undoStack: [],
 				redoStack: [],
 				selection: null,
 				dirty: false,
 				originalHash: "",
 			};
-		}
 
 		case "load-saved": {
+			const working = cloneMap(dispatch.working);
 			return {
 				...state,
-				working: cloneMap(dispatch.working),
-				history: [...dispatch.history],
+				working,
+				undoStack: [],
 				redoStack: [],
 				selection: null,
-				dirty: dispatch.history.length > 0,
+				dirty: !stableEqual(state.original, working),
 				originalHash: dispatch.originalHash,
 			};
 		}
 
 		case "apply": {
 			const { action } = dispatch;
+			const snapshot = cloneMap(state.working);
 			const working = cloneMap(state.working);
+			applyEdit(working, action);
+
+			const undoStack = [...state.undoStack, snapshot];
+			if (undoStack.length > UNDO_LIMIT) undoStack.shift();
+
 			const newState: EditorState = {
 				...state,
 				working,
-				history: [...state.history, action],
+				undoStack,
 				redoStack: [],
-				dirty: true,
+				dirty: !stableEqual(state.original, working),
 			};
 
-			applyForward(working, action);
-
-			// Determine target t for selection tracking
 			let targetT: number;
 			switch (action.type) {
 				case "move":
@@ -208,11 +140,7 @@ export function editorReducer(state: EditorState, dispatch: EditorDispatchAction
 					targetT = action.after.t;
 					break;
 				case "delete":
-					// Deselect on delete
-					return {
-						...newState,
-						selection: null,
-					};
+					return { ...newState, selection: null };
 				case "insert":
 					targetT = (action.value as { t: number }).t;
 					return resortAndTrackSelection(
@@ -230,83 +158,36 @@ export function editorReducer(state: EditorState, dispatch: EditorDispatchAction
 		}
 
 		case "undo": {
-			if (state.history.length === 0) return state;
-			const action = state.history[state.history.length - 1];
-			const working = cloneMap(state.working);
-
-			applyBackward(working, action);
-
-			const newState: EditorState = {
+			if (state.undoStack.length === 0) return state;
+			const previous = state.undoStack[state.undoStack.length - 1];
+			return {
 				...state,
-				working,
-				history: state.history.slice(0, -1),
-				redoStack: [...state.redoStack, action],
-				dirty: state.history.length > 1,
+				working: cloneMap(previous),
+				undoStack: state.undoStack.slice(0, -1),
+				redoStack: [...state.redoStack, cloneMap(state.working)],
+				selection: null,
+				dirty: !stableEqual(state.original, previous),
 			};
-
-			const arr = getLaneArray(working, action.lane);
-			sortByT(arr);
-
-			// Track selection
-			if (action.type === "delete") {
-				// Undo delete: reselect the restored event
-				const targetT = (action.value as { t: number }).t;
-				const idx = findIndexByT(arr, targetT, action.index);
-				return { ...newState, selection: { lane: action.lane, index: idx } };
-			}
-			if (action.type === "insert") {
-				// Undo insert: deselect
-				return { ...newState, selection: null };
-			}
-			if (action.type === "move" || action.type === "resize-start") {
-				const idx = findIndexByT(arr, action.before.t, action.index);
-				return { ...newState, selection: { lane: action.lane, index: idx } };
-			}
-
-			return newState;
 		}
 
 		case "redo": {
 			if (state.redoStack.length === 0) return state;
-			const action = state.redoStack[state.redoStack.length - 1];
-			const working = cloneMap(state.working);
-
-			applyForward(working, action);
-
-			const newState: EditorState = {
+			const next = state.redoStack[state.redoStack.length - 1];
+			return {
 				...state,
-				working,
-				history: [...state.history, action],
+				working: cloneMap(next),
+				undoStack: [...state.undoStack, cloneMap(state.working)],
 				redoStack: state.redoStack.slice(0, -1),
-				dirty: true,
+				selection: null,
+				dirty: !stableEqual(state.original, next),
 			};
-
-			const arr = getLaneArray(working, action.lane);
-			sortByT(arr);
-
-			if (action.type === "delete") {
-				return { ...newState, selection: null };
-			}
-			if (action.type === "move" || action.type === "resize-start") {
-				const idx = findIndexByT(arr, action.after.t, action.index);
-				return { ...newState, selection: { lane: action.lane, index: idx } };
-			}
-			if (action.type === "insert") {
-				const targetT = (action.value as { t: number }).t;
-				const idx = findIndexByT(arr, targetT, action.index);
-				return { ...newState, selection: { lane: action.lane, index: idx } };
-			}
-
-			return newState;
 		}
 
-		case "select": {
+		case "select":
 			return { ...state, selection: dispatch.selection };
-		}
 
-		case "deselect": {
+		case "deselect":
 			return { ...state, selection: null };
-		}
 
 		default:
 			return state;
@@ -317,7 +198,7 @@ export function createInitialState(map: PulseMap): EditorState {
 	return {
 		original: cloneMap(map),
 		working: cloneMap(map),
-		history: [],
+		undoStack: [],
 		redoStack: [],
 		selection: null,
 		dirty: false,

--- a/editor/src/state/types.ts
+++ b/editor/src/state/types.ts
@@ -8,6 +8,11 @@ export interface Selection {
 	index: number;
 }
 
+/**
+ * Dispatched edits. Not stored — the working map is the source of truth.
+ * The reducer applies each action directly to working and pushes a
+ * snapshot to undoStack for in-session undo.
+ */
 export type EditAction =
 	| {
 			type: "move";
@@ -66,13 +71,15 @@ export type EditorDispatchAction =
 	| { type: "select"; selection: Selection }
 	| { type: "deselect" }
 	| { type: "load"; map: PulseMap }
-	| { type: "load-saved"; working: PulseMap; history: EditAction[]; originalHash: string };
+	| { type: "load-saved"; working: PulseMap; originalHash: string };
 
 export interface EditorState {
 	original: PulseMap;
 	working: PulseMap;
-	history: EditAction[];
-	redoStack: EditAction[];
+	/** Snapshots of `working` taken before each apply, for in-session undo. */
+	undoStack: PulseMap[];
+	/** Snapshots popped by undo, available for redo. */
+	redoStack: PulseMap[];
 	selection: Selection | null;
 	dirty: boolean;
 	originalHash: string;


### PR DESCRIPTION
## Summary
The editor was tracking every dispatched `EditAction` and surfacing that history as the submission. Result: every keystroke became its own correction row, and net-zero edits still showed up in the PR. The action log was over-engineered — the product is "diff this JSON against upstream," not "replay user gestures."

This switches submission to a structural diff between `state.original` and `state.working`. Per-keystroke rows are gone; net-zero edits produce zero rows by definition.

## What changed
- **State.** `EditorState` drops `history: EditAction[]`. In-session undo/redo now uses a snapshot ring buffer of `working` (capped at 100, in-memory only).
- **Reducer.** Apply mutates `working` directly and pushes a snapshot. The `applyForward`/`applyBackward` pair collapses to one mutator.
- **`github/diff.ts`.** New `diffMaps(original, working)` computes a flat list of `DiffEntry` rows (field changes, inserts, deletes) by greedy best-fit matching of events between arrays — pairs scored by t-proximity + content similarity. Each entry is independently applicable, so per-row checkbox selection still works (`applyDiffEntries(original, selected)` rebuilds the submitted map).
- **`SubmitFlow`.** Takes `original` + `working`, runs the diff inline. `buildPrBody` emits structural deltas; the `<!-- pulsemap-correction -->` metadata block (consumed by `correction-provenance.yml`) is unchanged in shape.
- **`storage.ts`.** Payload is now `{working, savedAt, originalHash}`. Old saved entries with `history` are ignored on load, falling back to a clean session.
- **`DirtyIndicator`.** Drops the edit-count (computing it would re-run the diff on every render). Shows just "Unsaved" when dirty.

## User-facing behavior changes
- Per-keystroke rows in Submit Correction are gone — one row per actual field change.
- Net-zero edits produce zero rows.
- Cmd-Z now undoes the whole edit-session for a field at once instead of one keystroke at a time.
- Cross-reload undo is no longer supported; `working` itself is still restored from localStorage.

## Test plan
- [ ] Type into a chord/word/lyric/section text field; verify Submit shows ONE row with original→final, not one row per keystroke.
- [ ] Drag a chord; verify ONE row showing original t → final t.
- [ ] Edit two different fields on one event; verify two rows.
- [ ] Insert + delete on the timeline; verify they appear as `insert`/`delete` rows.
- [ ] Type a typo, then correct it back to the original value; verify the row disappears (net-zero).
- [ ] Cmd-Z still works in-session.
- [ ] Refresh editor mid-edit; `working` is restored, undo stack starts empty.
- [ ] Submit a correction PR end-to-end; verify the PR body shows structural deltas and `correction-provenance.yml` still parses the metadata block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)