### PR TITLE
chore: fix CI lint backlog (bootstrap formatting)

### DIFF
--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -16,16 +16,15 @@ import { extractAudio } from "./stages/extract-audio";
 import { fingerprint as computeFingerprint } from "./stages/fingerprint";
 import { crossValidateMidiChords, inferChordsMidi } from "./stages/infer-chords-midi";
 import { lookupRecording } from "./stages/lookup";
+import { detectLyricOffset } from "./stages/lyric-offset";
 import {
 	cleanYouTubeTitle,
 	extractYouTubeLyrics,
 	lookupLyrics,
 	searchLyrics,
 } from "./stages/lyrics";
-
 import { type StemPaths, separateAudio, separateVocals } from "./stages/separate";
 import { type TranscriptionResult, transcribeStem } from "./stages/transcribe";
-import { detectLyricOffset } from "./stages/lyric-offset";
 import { alignWords } from "./stages/word-align";
 
 export interface BootstrapOptions {
@@ -256,7 +255,10 @@ export async function bootstrap(source: string, options: BootstrapOptions = {}):
 							`shifted ${cleanedLyrics.length} lyrics by ${(offsetResult.offsetMs / 1000).toFixed(1)}s (similarity: ${(offsetResult.avgSimilarity * 100).toFixed(0)}%, was ${(offsetResult.zeroSimilarity * 100).toFixed(0)}%)`,
 						);
 					} else {
-						log.stageOk("lyric-offset", `no correction needed (similarity: ${(offsetResult.zeroSimilarity * 100).toFixed(0)}%)`);
+						log.stageOk(
+							"lyric-offset",
+							`no correction needed (similarity: ${(offsetResult.zeroSimilarity * 100).toFixed(0)}%)`,
+						);
 					}
 				}
 

--- a/src/bootstrap/stages/lyric-offset.ts
+++ b/src/bootstrap/stages/lyric-offset.ts
@@ -76,10 +76,7 @@ function scoreAtOffset(
 	return total;
 }
 
-export function detectLyricOffset(
-	lyrics: LyricLine[],
-	words: WordEvent[],
-): LyricOffsetResult {
+export function detectLyricOffset(lyrics: LyricLine[], words: WordEvent[]): LyricOffsetResult {
 	const clusters = clusterWords(words);
 	const linesNormed = lyrics.map((l) => ({ t: l.t, words: normalize(l.text) }));
 	const clustersNormed = clusters.map((c) => ({ t: c.t, words: normalize(c.text) }));

--- a/src/bootstrap/stages/reconcile-words.ts
+++ b/src/bootstrap/stages/reconcile-words.ts
@@ -42,7 +42,8 @@ function buildChunks(lyrics: LyricLine[], words: WordEvent[]): LineChunk[] {
 	for (let l = 0; l < lyrics.length; l++) {
 		const windowStart = boundaries[l];
 		const windowEnd = l + 1 < boundaries.length ? boundaries[l + 1] : Number.POSITIVE_INFINITY;
-		const nextLineStart = l + 1 < lyrics.length ? (lyrics[l].t + lyrics[l + 1].t) / 2 : Number.POSITIVE_INFINITY;
+		const nextLineStart =
+			l + 1 < lyrics.length ? (lyrics[l].t + lyrics[l + 1].t) / 2 : Number.POSITIVE_INFINITY;
 
 		const chunkWords: { index: number; text: string }[] = [];
 		for (const w of sorted) {
@@ -63,7 +64,10 @@ function formatChunkedPrompt(
 	chunks: LineChunk[],
 	metadata: { title?: string; artist?: string },
 ): string {
-	const lines: string[] = [`Song: ${metadata.title || "Unknown"} by ${metadata.artist || "Unknown"}`, ""];
+	const lines: string[] = [
+		`Song: ${metadata.title || "Unknown"} by ${metadata.artist || "Unknown"}`,
+		"",
+	];
 
 	for (let c = 0; c < chunks.length; c++) {
 		const chunk = chunks[c];

--- a/src/bootstrap/test-sliding-offset.ts
+++ b/src/bootstrap/test-sliding-offset.ts
@@ -95,7 +95,9 @@ function findBestOffset(
 	const avgSim = lrclibLines.length > 0 ? bestScore / lrclibLines.length : 0;
 	const improvement = lrclibLines.length > 0 ? (bestScore - zeroScore) / lrclibLines.length : 0;
 	const accepted =
-		Math.abs(bestOffset) > 2000 && avgSim >= SIMILARITY_THRESHOLD && improvement >= IMPROVEMENT_THRESHOLD;
+		Math.abs(bestOffset) > 2000 &&
+		avgSim >= SIMILARITY_THRESHOLD &&
+		improvement >= IMPROVEMENT_THRESHOLD;
 
 	return { offsetMs: bestOffset, score: bestScore, zeroScore, accepted };
 }

--- a/src/bootstrap/test-vocal-offset.ts
+++ b/src/bootstrap/test-vocal-offset.ts
@@ -10,9 +10,9 @@
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import type { PulseMap } from "../../schema/map";
+import { resolvePython } from "./python";
 import { extractAudio } from "./stages/extract-audio";
 import { separateAudio } from "./stages/separate";
-import { resolvePython } from "./python";
 
 async function main() {
 	const mapPath = process.argv[2];
@@ -79,7 +79,9 @@ async function main() {
 
 		const result = JSON.parse(stdout.trim());
 		const onsetMs: number = result.onset_ms;
-		console.log(`  → first vocal onset: ${onsetMs}ms (${(onsetMs / 1000).toFixed(1)}s), RMS: ${result.rms_db}dB`);
+		console.log(
+			`  → first vocal onset: ${onsetMs}ms (${(onsetMs / 1000).toFixed(1)}s), RMS: ${result.rms_db}dB`,
+		);
 
 		const firstLyricT = lyrics[0].t;
 		const offset = onsetMs - firstLyricT;
@@ -102,7 +104,9 @@ async function main() {
 
 		if (words.length) {
 			const wordDelta = words[0].t - onsetMs;
-			console.log(`\nWhisperX first word vs onset: ${wordDelta}ms (${(wordDelta / 1000).toFixed(1)}s)`);
+			console.log(
+				`\nWhisperX first word vs onset: ${wordDelta}ms (${(wordDelta / 1000).toFixed(1)}s)`,
+			);
 		}
 	} finally {
 		const proc = Bun.spawn(["rm", "-rf", workDir], { stdout: "ignore", stderr: "ignore" });


### PR DESCRIPTION
## Summary
CI lint has been failing on a backlog of biome format and import-order errors in \`src/bootstrap/\`. Auto-fixed via \`biome check --write\` — all formatting and import-sort, no logic changes.

After this lands, CI \`bun run lint\` exits 0. Recent PRs (#39–#42) had to be merged with admin override to bypass this; that workaround is no longer needed.

## What's left (warning/info level, not blocking CI)
- \`useParseIntRadix\` in \`src/bootstrap/stages/lyrics.ts\` (6 calls) — add \`, 10\` radix arg.
- \`noUnusedVariables\` in \`src/bootstrap/stages/clean-chords.ts\` (\`parseChordRoot\`, \`diatonicRoots\`) — leftover dead code from an earlier filter design.
- \`useTemplate\` warnings in \`tools/map-inspector.html\` — string concat → template literal.

Worth a follow-up pass; not in scope here.

## Test plan
- [ ] CI \`Lint\` step passes (was the actual blocker).
- [ ] Typecheck and tests still pass.
- [ ] No bootstrap behavior change — pure formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)