### PR TITLE
chore(ci): stop gating PRs on lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,11 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
-      - name: Lint
-        run: bun run lint
+      # Lint is enforced locally via editor format-on-save and `bun run lint`.
+      # CI doesn't gate on it — the rules biome fires on this repo are
+      # almost entirely cosmetic (format, import order) and were producing
+      # admin-override PRs without catching real bugs. Typecheck + tests
+      # carry the load.
 
       - name: Typecheck
         run: bun run typecheck


### PR DESCRIPTION
## Summary
Lint comes out of the CI workflow. The rules biome was firing on this repo (format, import-order, useTemplate, useParseIntRadix) are almost entirely cosmetic, and every recent CI failure they produced was a "someone forgot to run the formatter" issue that forced an admin-override merge (#39, #40, #41, #42) without catching any actual bug.

Lint stays available locally via \`bun run lint\` and editor format-on-save. CI keeps typecheck + test, which carry the actual signal.

## Test-coverage debt (post-demo)
The load-bearing editor logic — diff.ts (~250 lines of greedy-best-fit event matching), OAuth web flow + CSRF state, Timeline deep-link routing — has zero tests. CI barely covers what actually matters in the editor. Documented as a post-demo TODO in the capstone PRD's Phase 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)