### PR TITLE
fix: loose ends from the OAuth + diff-submission session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,15 @@ jobs:
       # admin-override PRs without catching real bugs. Typecheck + tests
       # carry the load.
 
-      - name: Typecheck
+      - name: Typecheck (root)
+        run: bun run typecheck
+
+      - name: Install editor deps
+        working-directory: editor
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck (editor)
+        working-directory: editor
         run: bun run typecheck
 
       - name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ batch-results.json
 # maps/midi/*.mid IS tracked for distribution
 *.midi
 .venv/
+
+# Agent worktrees (orchestrator scaffolding)
+.claude/worktrees/

--- a/editor/src/App.tsx
+++ b/editor/src/App.tsx
@@ -270,6 +270,7 @@ function EditorContent({
 				position={position}
 				playing={playing}
 				onSeek={onSeek}
+				playbackAvailable={playbackAvailable}
 				playbackReady={playbackReady}
 				snapEnabled={snapEnabled}
 				snapSubdivision={snapSubdivision}

--- a/editor/src/components/GitHubAuth.tsx
+++ b/editor/src/components/GitHubAuth.tsx
@@ -1,5 +1,11 @@
 import { type CSSProperties, useCallback, useEffect, useState } from "react";
-import { beginOAuth, clearToken, getStoredToken, validateToken } from "../github/auth";
+import {
+	beginOAuth,
+	clearToken,
+	consumeOAuthError,
+	getStoredToken,
+	validateToken,
+} from "../github/auth";
 
 interface GitHubAuthProps {
 	onAuthChange: (token: string | null, login: string | null) => void;
@@ -8,8 +14,12 @@ interface GitHubAuthProps {
 export function GitHubAuth({ onAuthChange }: GitHubAuthProps) {
 	const [login, setLogin] = useState<string | null>(null);
 	const [checking, setChecking] = useState(true);
+	const [error, setError] = useState<string | null>(null);
 
 	useEffect(() => {
+		const oauthError = consumeOAuthError();
+		if (oauthError) setError(oauthError);
+
 		const token = getStoredToken();
 		if (!token) {
 			setChecking(false);
@@ -30,6 +40,7 @@ export function GitHubAuth({ onAuthChange }: GitHubAuthProps) {
 	}, [onAuthChange]);
 
 	const handleSignIn = useCallback(() => {
+		setError(null);
 		beginOAuth();
 	}, []);
 
@@ -59,6 +70,7 @@ export function GitHubAuth({ onAuthChange }: GitHubAuthProps) {
 			<button type="button" onClick={handleSignIn} style={styles.signIn}>
 				Sign in with GitHub
 			</button>
+			{error && <span style={styles.error}>{error}</span>}
 		</span>
 	);
 }
@@ -94,5 +106,10 @@ const styles: Record<string, CSSProperties> = {
 		color: "#8b949e",
 		fontSize: 11,
 		cursor: "pointer",
+	},
+	error: {
+		fontSize: 11,
+		color: "#f85149",
+		maxWidth: 240,
 	},
 };

--- a/editor/src/components/SubmitFlow.tsx
+++ b/editor/src/components/SubmitFlow.tsx
@@ -29,7 +29,10 @@ export function SubmitFlow({
 	const [prUrl, setPrUrl] = useState<string | undefined>();
 	const [submitError, setSubmitError] = useState<string | undefined>();
 
-	const entries = useMemo(() => diffMaps(original, working), [original, working]);
+	// Snapshot working at modal open so the diff doesn't shift under the
+	// user's checkboxes if they keep editing while the modal is open.
+	const [snapshot] = useState(working);
+	const entries = useMemo(() => diffMaps(original, snapshot), [original, snapshot]);
 	const [checkedIndices, setCheckedIndices] = useState<Set<number>>(
 		() => new Set(entries.map((_, i) => i)),
 	);

--- a/editor/src/components/Timeline.tsx
+++ b/editor/src/components/Timeline.tsx
@@ -21,6 +21,7 @@ interface TimelineProps {
 	position: number;
 	playing: boolean;
 	onSeek: (ms: number) => void;
+	playbackAvailable: boolean;
 	playbackReady: boolean;
 	snapEnabled: boolean;
 	snapSubdivision: SnapSubdivision;
@@ -87,6 +88,7 @@ export function Timeline({
 	position,
 	playing,
 	onSeek,
+	playbackAvailable,
 	playbackReady,
 	snapEnabled,
 	snapSubdivision,
@@ -138,11 +140,14 @@ export function Timeline({
 			deepLinkApplied.current = true;
 			return;
 		}
-		if (t != null && !playbackReady) return;
+		// Wait for the YouTube player to be ready before seeking, but only
+		// if playback is actually available — when no playback target was
+		// found (playbackAvailable=false) we still want to scroll/select.
+		if (t != null && playbackAvailable && !playbackReady) return;
 		deepLinkApplied.current = true;
 
 		if (t != null) {
-			onSeek(t);
+			if (playbackAvailable) onSeek(t);
 			disableFollow();
 			const el = containerRef.current;
 			if (el) {
@@ -170,6 +175,7 @@ export function Timeline({
 		}
 	}, [
 		deepLink,
+		playbackAvailable,
 		playbackReady,
 		onSeek,
 		disableFollow,

--- a/editor/src/github/api.ts
+++ b/editor/src/github/api.ts
@@ -146,7 +146,10 @@ export async function submitCorrection(
 		// File doesn't exist yet — new map
 	}
 
-	const content = btoa(unescape(encodeURIComponent(JSON.stringify(map, null, 2))));
+	// Trailing newline matches the repo's existing JSON files (and what most
+	// formatters emit), so the diff stays clean instead of adding a "no
+	// newline at end of file" marker on every correction.
+	const content = btoa(unescape(encodeURIComponent(`${JSON.stringify(map, null, 2)}\n`)));
 	await ghJson<{ commit: { sha: string } }>(
 		`/repos/${username}/${UPSTREAM_REPO}/contents/${filePath}`,
 		token,

--- a/editor/src/github/auth.ts
+++ b/editor/src/github/auth.ts
@@ -18,6 +18,7 @@ const CLIENT_ID = "Ov23liuBjPclnX0rAr1s";
 const TOKEN_KEY = "pulsemap-gh-token";
 const STATE_KEY = "pulsemap-oauth-state";
 const RETURN_URL_KEY = "pulsemap-oauth-return-url";
+const ERROR_KEY = "pulsemap-oauth-error";
 const REDIRECT_URI = "https://hartphoenix.github.io/pulsemap/editor/";
 
 const PROXY_URL =
@@ -72,7 +73,12 @@ export async function handleOAuthCallback(): Promise<boolean> {
 		window.history.replaceState(null, "", target);
 	};
 
+	const surfaceError = (message: string) => {
+		sessionStorage.setItem(ERROR_KEY, message);
+	};
+
 	if (!expected || expected !== state) {
+		surfaceError("Sign-in state didn't match — please try again.");
 		restore();
 		return true;
 	}
@@ -87,14 +93,34 @@ export async function handleOAuthCallback(): Promise<boolean> {
 			const data = (await res.json()) as { access_token?: string };
 			if (data.access_token) {
 				localStorage.setItem(TOKEN_KEY, data.access_token);
+			} else {
+				surfaceError("Sign-in failed: no token returned. Please try again.");
 			}
+		} else {
+			let detail = `${res.status}`;
+			try {
+				const body = (await res.json()) as { error?: string; error_description?: string };
+				if (body.error_description) detail = body.error_description;
+				else if (body.error) detail = body.error;
+			} catch {
+				// non-JSON body — keep the status code as the detail
+			}
+			surfaceError(`Sign-in failed: ${detail}`);
 		}
-	} catch {
-		// network error — token not stored; user will see signed-out state
+	} catch (err) {
+		const detail = err instanceof Error ? err.message : "network error";
+		surfaceError(`Sign-in failed: ${detail}`);
 	}
 
 	restore();
 	return true;
+}
+
+/** Read and clear any pending OAuth error stashed by handleOAuthCallback. */
+export function consumeOAuthError(): string | null {
+	const msg = sessionStorage.getItem(ERROR_KEY);
+	if (msg) sessionStorage.removeItem(ERROR_KEY);
+	return msg;
 }
 
 /** Read stored token from localStorage. */

--- a/editor/src/hooks/useTimeline.ts
+++ b/editor/src/hooks/useTimeline.ts
@@ -136,6 +136,7 @@ export function useTimeline({
 			// Horizontal scroll component (trackpad swipe or shift+scroll)
 			if (e.deltaX !== 0) {
 				e.preventDefault();
+				if (!el) return;
 				const maxScrollMs = Math.max(0, (el.scrollWidth - el.clientWidth) / pxPerMs);
 				const deltaMs = e.deltaX / pxPerMs;
 				setScrollMs((prev) => Math.max(0, Math.min(prev + deltaMs, maxScrollMs)));

--- a/src/bootstrap/stages/clean-chords.ts
+++ b/src/bootstrap/stages/clean-chords.ts
@@ -2,47 +2,8 @@ import type { BeatEvent, ChordEvent } from "../../../schema/map";
 
 export interface ChordCleanupOptions {
 	beats: BeatEvent[];
+	/** Reserved for future diatonic-root filtering; currently unused. */
 	key?: string;
-}
-
-const NOTE_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
-const ENHARMONIC: Record<string, string> = {
-	Db: "C#",
-	Eb: "D#",
-	Fb: "E",
-	Gb: "F#",
-	Ab: "G#",
-	Bb: "A#",
-	Cb: "B",
-	"E#": "F",
-	"B#": "C",
-};
-
-const MAJOR_SCALE_STEPS = [0, 2, 4, 5, 7, 9, 11];
-const MINOR_SCALE_STEPS = [0, 2, 3, 5, 7, 8, 10];
-
-function normalizeNote(note: string): string {
-	return ENHARMONIC[note] ?? note;
-}
-
-function noteIndex(note: string): number {
-	return NOTE_NAMES.indexOf(normalizeNote(note));
-}
-
-function parseChordRoot(chord: string): string | undefined {
-	const m = chord.match(/^([A-G][#b]?)/);
-	return m?.[1];
-}
-
-function getDiatonicRoots(key: string): Set<string> {
-	const parts = key.split(/\s+/);
-	const root = parts[0];
-	const mode = parts[1]?.toLowerCase();
-	const rootIdx = noteIndex(root);
-	if (rootIdx < 0) return new Set();
-
-	const steps = mode === "minor" ? MINOR_SCALE_STEPS : MAJOR_SCALE_STEPS;
-	return new Set(steps.map((s) => NOTE_NAMES[(rootIdx + s) % 12]));
 }
 
 function getBpm(beats: BeatEvent[]): number | undefined {
@@ -60,7 +21,6 @@ export function cleanChords(chords: ChordEvent[], options: ChordCleanupOptions):
 
 	const eighthMs = 60000 / bpm / 2;
 	const minChordMs = Math.max(300, eighthMs);
-	const diatonicRoots = options.key ? getDiatonicRoots(options.key) : undefined;
 
 	const filtered: ChordEvent[] = [];
 

--- a/src/bootstrap/stages/lyrics.ts
+++ b/src/bootstrap/stages/lyrics.ts
@@ -93,15 +93,15 @@ export function parseVtt(vtt: string): LyricLine[] | undefined {
 		if (!m) continue;
 
 		const startMs =
-			Number.parseInt(m[1]) * 3_600_000 +
-			Number.parseInt(m[2]) * 60_000 +
-			Number.parseInt(m[3]) * 1000 +
-			Number.parseInt(m[4]);
+			Number.parseInt(m[1], 10) * 3_600_000 +
+			Number.parseInt(m[2], 10) * 60_000 +
+			Number.parseInt(m[3], 10) * 1000 +
+			Number.parseInt(m[4], 10);
 		const endMs =
-			Number.parseInt(m[5]) * 3_600_000 +
-			Number.parseInt(m[6]) * 60_000 +
-			Number.parseInt(m[7]) * 1000 +
-			Number.parseInt(m[8]);
+			Number.parseInt(m[5], 10) * 3_600_000 +
+			Number.parseInt(m[6], 10) * 60_000 +
+			Number.parseInt(m[7], 10) * 1000 +
+			Number.parseInt(m[8], 10);
 
 		const textParts = blockLines.slice(textStartIndex);
 		const text = textParts


### PR DESCRIPTION
## Summary
Cleanup pass on items surfaced when reviewing the work from PRs #39–#44. All editor-side, all small.

## Items addressed
1. **Deep-link routing no-op on silent maps.** Timeline's effect was gated on \`playbackReady\`, which never flips when there's no YouTube target. Now: \`(playbackReady || !playbackAvailable)\`.
2. **Trailing newline on submitted JSON.** \`api.ts\` now appends \`\\n\` so PR diffs don't pick up a "No newline at end of file" marker on every correction.
3. **SubmitFlow stale checkboxes.** Modal snapshots \`working\` at open; the diff doesn't shift under the user's checkboxes if they keep editing.
4. **Silent OAuth callback failures.** State mismatch, proxy 4xx/5xx, network errors now stash a message in sessionStorage; GitHubAuth surfaces it inline next to Sign in. Previously the user just landed back on their map page logged-out with no explanation.
5. **\`useTimeline.ts:139\` null-safety + CI typecheck gap.** Real null-safety bug fixed. Root \`tsconfig.json\` doesn't include \`editor/\`, so CI typecheck never saw editor errors. Added \`editor/\` typecheck as a CI step.
6. **Three stale lint warnings.** \`useParseIntRadix\` in \`lyrics.ts\` (added \`, 10\`); dead code removed from \`clean-chords.ts\` (\`parseChordRoot\`, \`getDiatonicRoots\`, and their support constants — unused since the cleanup stage was first written).
7. **\`.gitignore\`.** Picked up the \`.claude/worktrees/\` entry that had been pending uncommitted.

## Test plan
- [ ] CI passes (now also typechecks editor/).
- [ ] Open a map without a YouTube target via deep link — timeline scrolls + selection happens (no playback).
- [ ] Submit a correction PR — file ends with \`\\n\`, no "no newline" marker on the diff.
- [ ] Sign in, deliberately fail (e.g., let proxy 500) — error message visible inline.
- [ ] Cmd-Z still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)