### PR TITLE
docs: rewrite README + expand sdk/README + unify version semantics (PR 1/6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,138 @@
 # PulseMap
 
-An open-source protocol for mapping time-based media and layering synchronized experiences on top.
+**An open-source protocol for mapping time-based media and layering synchronized experiences on top.**
 
-## What is PulseMap?
+`alpha` · `v0.1.0` · `MIT`
 
-A **map** describes the inherent structure of a song or recording — chords, lyrics, beats, sections, tempo, fingerprint. It's source-agnostic: the same map works whether you're playing from YouTube, Spotify, a local file, or live audio.
+A **map** describes the inherent structure of a recording — chords, lyrics, words, beats, sections, tempo, key, fingerprint, MIDI references. It's source-agnostic: the same map works whether you're playing from YouTube, Spotify, a local audio file, or live audio.
 
-A **journey** describes a path through that map with synchronized events — lessons, visualizations, annotations, lighting cues, anything. Journeys reference maps but never modify them. One recording, one map, unlimited journeys.
+A **journey** is a path through that map with synchronized events — lessons, audio overdubs, annotations, lighting cues, anything. Journeys reference maps but never modify them. *One recording, one map, unlimited journeys.* PulseMap defines maps and ships a suggested journey reference shape; everything layered on top is open territory.
 
-## Protocol
+The schema, the SDK, the bootstrap pipeline, the deployed Map Editor, and the 100+ map dataset are all in this repo. The companion player [PulseGuide](https://hartphoenix.github.io/pulseguide/) is a separate repo that uses PulseMap as a dependency and demonstrates the full protocol in action.
 
-Maps and journeys are JSON files. See [`schema/`](./schema/) for the format specification.
+## See it running
 
-### Map (required fields)
+<!-- TODO(SCREENSHOT): docs/screenshots/pulseguide-leadsheet.png — Pulseguide showing a synced lead sheet (chords + lyrics) for a real song. Replace this comment with: ![Pulseguide playing a song](docs/screenshots/pulseguide-leadsheet.png) -->
 
-```json
+| | |
+|---|---|
+| **PulseGuide** (live demo player) | <https://hartphoenix.github.io/pulseguide/> |
+| **Map Editor** (correct any map) | <https://hartphoenix.github.io/pulsemap/editor/0cdc9b5b-b16b-4ff1-9f16-5b4ba76f1c17> |
+| **Maps catalog** (100+ maps, JSON) | <https://hartphoenix.github.io/pulsemap/maps/manifest.json> |
+
+<!-- TODO(DEMO-MAP-ID): the editor link above points at "Let It Be" (0cdc9b5b-...). Hart should pick a final demo map. Strong candidates: Bob Dylan – Blowin' in the Wind (00e37446-...), The Beatles – Let It Be (0cdc9b5b-...), Leonard Cohen – Hallelujah (0ef6d5e2-...), Adele – Someone Like You (028efe7f-...). -->
+
+## What a map looks like
+
+```jsonc
 {
-  "version": "0.1",
-  "id": "<MusicBrainz recording ID>",
-  "duration_ms": 234000
+  "version": "0.1.0",
+  "id": "0cdc9b5b-b16b-4ff1-9f16-5b4ba76f1c17",   // MusicBrainz recording ID
+  "duration_ms": 243030,
+  "metadata": {
+    "title": "Let It Be",
+    "artist": "The Beatles",
+    "key": "C major",
+    "tempo": 69.8,
+    "time_signature": "4/4"
+  },
+  "playback": [{
+    "platform": "youtube",
+    "uri": "https://www.youtube.com/watch?v=QDYfEBY9NM4",
+    "id": "QDYfEBY9NM4",
+    "capabilities": { "play": true, "pause": true, "seek": true, "volume": true, "mute": true }
+  }],
+  "lyrics":  [{ "t": 12670, "end": 17170, "text": "When I find myself in times of trouble" }],
+  "words":   [{ "t": 12670, "end": 12880, "text": "When" }],
+  "chords":  [{ "t":    20, "end":  1700, "chord": "C" }],
+  "beats":   [{ "t":    40, "downbeat": true, "bpm": 72.3, "time_sig": "4/4" }],
+  "sections": [],
+  "midi": []
 }
 ```
 
-Optional fields: `fingerprint`, `metadata`, `playback`, `lyrics`, `chords`, `beats`, `sections`, `midi`, `analysis`.
+All timestamps are milliseconds. Musical data is transposable at render time. Per-field provenance lives in a top-level `analysis` field. Per-stem MIDI (drums, bass, vocals, other, backing) is referenced by SHA-256 content hash, not embedded. Full type definitions in [`schema/map.ts`](./schema/map.ts).
 
-All timestamps are in milliseconds. Musical data is transposable at render time. Provenance for analyzed fields is tracked in `analysis`.
+## Use it from your code
 
-### Bootstrap
+Install via the GitHub URL — npm publish is on the roadmap:
 
-The bootstrap script generates maps from audio or video sources:
-
-```bash
-bun run bootstrap -- --url "https://youtube.com/watch?v=..."
+```jsonc
+// package.json
+{
+  "dependencies": {
+    "pulsemap": "github:hartphoenix/pulsemap"
+  }
+}
 ```
 
-Pipeline: audio → fpcalc (fingerprint) → LRCLIB (lyrics) → basic-pitch (MIDI) → essentia (chords, beats, sections) → map JSON.
+```ts
+import { YouTubeEmbedAdapter, createRegistry, youTubeEmbedMatcher } from "pulsemap/sdk";
+import type { PulseMap } from "pulsemap/schema";
 
-## Development
+const registry = createRegistry([youTubeEmbedMatcher]);
+const { sourceId } = registry.resolve(map.playback[0].uri)!;
 
-```bash
-bun install
-bun test
-bun run lint
-bun run typecheck
+const adapter = new YouTubeEmbedAdapter({ elementId: "player", videoId: sourceId });
+await adapter.waitForReady();
+adapter.play();
+
+adapter.onStateChange(state => console.log(state));   // "playing" | "paused" | "ended" | ...
+setInterval(() => render(map, adapter.getPosition()), 50);
 ```
+
+Adapters declare what they can do via a `PlaybackCapabilities` object — feature-detect before calling optional methods like `setPlaybackRate` or `setVolume`.
+
+See [`sdk/README.md`](./sdk/README.md) for the full SDK reference and [`sdk/ADAPTERS.md`](./sdk/ADAPTERS.md) for building your own adapter.
+
+## Adapter catalog
+
+| Adapter | Platform | Status |
+|---|---|---|
+| `YouTubeEmbedAdapter` | YouTube | shipped |
+| `HtmlAudioAdapter` | `<audio>` element (URL, Blob, File) | next |
+| `WebAudioAdapter` | `AudioContext` graph | [good first issue](https://github.com/hartphoenix/pulsemap/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) |
+| Spotify | Spotify Web Playback | open invitation |
+| SoundCloud | Widget API | open invitation |
+| Apple Music | MusicKit JS | open invitation |
+| Bandcamp | embed | open invitation |
+| HLS / DASH | Shaka Player | open invitation |
+
+The adapter contract is small, public, and unowned. Build whatever adapters your app needs in your own repo, on your own terms — contribution back upstream is optional and appreciated.
+
+## Repo structure
+
+```
+schema/              TypeScript types for the map format (and the suggested journey shape)
+sdk/
+  adapters/          PlaybackAdapter interface + reference adapters
+  editor/            openEditor() / editorUrl() — link any player to the hosted editor
+  playback.ts        parsePlaybackTarget(url) — URL → PlaybackTarget
+  README.md          SDK reference
+  ADAPTERS.md        How to build an adapter
+src/
+  bootstrap/         Map generation pipeline (audio → map JSON)
+  db/                SQLite map database utilities
+editor/              Standalone Map Editor (Vite + React) — deployed to GitHub Pages
+maps/                Generated map JSON files (committed for distribution)
+docs/proposals/      RFCs for protocol extensions
+.github/             CI workflows + issue/PR templates
+```
+
+## Contribute
+
+| Want to … | Where to go |
+|---|---|
+| Fix a chord, lyric, or timing in a map | Use the **[Map Editor](https://hartphoenix.github.io/pulsemap/editor/)** — it generates a PR with the right provenance. **Map corrections do not go through issues.** |
+| Build an adapter for a platform | Read [`sdk/ADAPTERS.md`](./sdk/ADAPTERS.md), then file an [Adapter proposal](https://github.com/hartphoenix/pulsemap/issues/new?template=adapter-proposal.yml) issue |
+| Report a bug or propose a change | Open an [issue](https://github.com/hartphoenix/pulsemap/issues/new/choose) |
+| Hack on the schema, SDK, pipeline, or editor | Read [`CONTRIBUTING.md`](./CONTRIBUTING.md) |
+
+## Status
+
+PulseMap is alpha. The map schema is stable in shape but not in semver — breaking changes are possible until `v1.0`. Versioning is unified: the package version *is* the schema version (see [`schema/VERSIONING.md`](./schema/VERSIONING.md)). Journeys are an open layer on top — the [`schema/journey.ts`](./schema/journey.ts) reference shape is a suggestion, not a controlled spec.
+
+The flagship open problem is **windowed-fingerprint partial-audio recognition** — see [`docs/proposals/0001-windowed-fingerprints.md`](./docs/proposals/0001-windowed-fingerprints.md). If you've worked on audio fingerprinting, ANN search, or indexing, that proposal is where to start the conversation.
 
 ## License
 

--- a/schema/map.ts
+++ b/schema/map.ts
@@ -183,7 +183,10 @@ export const CorrectionEntrySchema = Type.Object({
 export type CorrectionEntry = Static<typeof CorrectionEntrySchema>;
 
 export const PulseMapSchema = Type.Object({
-	version: Type.String({ description: "Schema version (semver)." }),
+	version: Type.String({
+		description:
+			"Schema version (semver). Matches the PulseMap package version: one source of truth, one number. See schema/VERSIONING.md.",
+	}),
 	id: Type.String({ description: "MusicBrainz recording ID." }),
 	duration_ms: Type.Number({
 		description: "Total duration of the recording in milliseconds.",

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,6 +1,18 @@
 # PulseMap Adapter SDK
 
-Reference playback adapters for the PulseMap protocol. Use these to build players that consume PulseMap files.
+Reference playback adapters for the PulseMap protocol. Use these to build players that consume PulseMap files, or implement your own.
+
+## Why this exists
+
+Every player that wants to consume PulseMap data needs to control playback on *some* underlying media source — YouTube, Spotify, an `<audio>` element, a Web Audio graph, a DAW host. The protocol defines [`PlaybackCapabilities`](../schema/map.ts) as a *catalog* of what platforms can do (play, pause, seek, rate, volume, mute). The SDK ships an implementation of that catalog: the `PlaybackAdapter` interface and a few reference adapters.
+
+Programming against `PlaybackAdapter` instead of the platform's native API means the rest of your app — sync engine, lead sheet rendering, lyric highlighting, recording, corrections — does not need to know whether the source is YouTube or local audio. You swap adapters; everything downstream just works.
+
+The adapter contract is small, public, and unowned. Build whatever adapters your app needs in your own repo, on your own terms. If you want to contribute one back upstream the handshake is documented in [`ADAPTERS.md`](./ADAPTERS.md), but that's optional.
+
+## Used in
+
+- [PulseGuide](https://hartphoenix.github.io/pulseguide/) ([repo](https://github.com/hartphoenix/pulseguide)) — synced lead-sheet player. Imports the SDK directly via `pulsemap/sdk`.
 
 ## Quick start
 
@@ -76,7 +88,7 @@ if (result) {
 
 ## Building a custom adapter
 
-Implement `PlaybackAdapter` and provide an `AdapterMatcher`:
+Implement `PlaybackAdapter` and (optionally) provide an `AdapterMatcher`:
 
 ```typescript
 import type { PlaybackAdapter, AdapterMatcher } from "pulsemap/sdk";
@@ -95,10 +107,25 @@ export class MyAdapter implements PlaybackAdapter {
 }
 ```
 
-Contributions welcome — if your adapter works well, consider opening a PR to add it to the SDK.
+Full walk-through: [`ADAPTERS.md`](./ADAPTERS.md) — anatomy of a 50-line adapter, capability declaration, testing patterns, and the optional handshake for upstreaming.
 
 ## Available adapters
 
 | Adapter | Platform | Environment |
 |---------|----------|-------------|
 | `YouTubeEmbedAdapter` | YouTube | Browser (iframe API) |
+
+## Wanted — open invitations
+
+Each row links to the [adapter-proposal issue template](https://github.com/hartphoenix/pulsemap/issues/new?template=adapter-proposal.yml). If you're already building one for your own app, you don't need to file an issue first — feel free to ship it as a PR directly.
+
+| Adapter | Platform |
+|---|---|
+| `HtmlAudioAdapter` | `<audio>` element (URL, Blob, File) |
+| `WebAudioAdapter` | `AudioContext` graph + analyzer |
+| `SpotifyAdapter` | Spotify Web Playback (premium) |
+| `SoundCloudAdapter` | SoundCloud Widget API |
+| `AppleMusicAdapter` | MusicKit JS |
+| `BandcampAdapter` | Bandcamp embed |
+| `HlsAdapter` / `DashAdapter` | Shaka Player (live and pre-recorded streams) |
+| Native DAW bridge | OSC / MIDI / WebSocket to a host (Ableton, Reaper, Logic) |


### PR DESCRIPTION
## Summary

PR 1 of the [demo-day legibility plan](../). Pure documentation.

- **`README.md`** — full rewrite. One-line pitch + status block; what a map is + what a journey is; live-demo block linking PulseGuide, the editor, and the maps catalog; trimmed map JSON example; SDK quick-start with the `github:` install path; adapter catalog (YouTube shipped, HtmlAudio "next," everything else open invitation); repo structure tree; **a contribute table that explicitly routes map corrections to the editor, not issues**; status section pointing at the windowed-fingerprints RFC.
- **`sdk/README.md`** — adds a "Why this exists" framing paragraph; "Used in" section linking PulseGuide; explicit handoff to `sdk/ADAPTERS.md`; a "Wanted — open invitations" table linking the adapter-proposal issue template. Tone shift: build adapters on your own terms; contribution upstream is optional.
- **`schema/map.ts`** — clarifies the `version` field: schema version equals PulseMap package version (one semver, one source of truth).

## Two TODO placeholders for Hart

Both are tagged with `<!-- TODO(...) -->` comments inline in `README.md`:

1. **Screenshot** for the live-demo block (`docs/screenshots/pulseguide-leadsheet.png`).
2. **Final demo map id** for the editor live-link (currently `0cdc9b5b-...` = Let It Be; alternates listed inline: Blowin' in the Wind, Hallelujah, Someone Like You).

## Dependencies on later PRs

`README.md` and `sdk/README.md` reference files that ship in upcoming PRs (`CONTRIBUTING.md`, `sdk/ADAPTERS.md`, `schema/VERSIONING.md`, `schema/journey.ts`, `docs/proposals/0001-windowed-fingerprints.md`). Merge PR 2 and PR 5 within the same demo-day window to avoid temporary 404s on those internal links.

## Test plan

- [ ] `bun run typecheck` passes locally (verified)
- [ ] `bun run lint` — no new warnings introduced (only pre-existing warnings in `src/bootstrap/scripts/` unrelated to this PR)
- [ ] README renders cleanly on the GitHub preview
- [ ] Live-demo links resolve:
  - <https://hartphoenix.github.io/pulseguide/>
  - <https://hartphoenix.github.io/pulsemap/editor/0cdc9b5b-b16b-4ff1-9f16-5b4ba76f1c17>
  - <https://hartphoenix.github.io/pulsemap/maps/manifest.json>

🤖 Generated with [Claude Code](https://claude.com/claude-code)