### PR TITLE
feat(schema): journey reference shape + VERSIONING + windowed-fingerprints RFC (PR 5/6)

### DIFF
--- a/docs/proposals/0001-windowed-fingerprints.md
+++ b/docs/proposals/0001-windowed-fingerprints.md
@@ -1,0 +1,136 @@
+# RFC 0001 — Windowed fingerprints for partial-audio recognition
+
+**Status:** draft · **Authors:** @hartphoenix · **Created:** 2026-05-01
+
+This is a written design proposal. Code is intentionally not yet shipped — the proposal exists so contributors with audio fingerprinting / approximate-search / indexing background can engage with the open questions before we commit to an implementation.
+
+## Motivation
+
+Today, a PulseMap's `fingerprint` field carries a **single Chromaprint** computed over the entire recording. This is useful for full-track identification *after* you already have the whole audio (the AcoustID flow: fingerprint a file → match it to a MusicBrainz recording id).
+
+What it doesn't unlock: **identifying a song from a brief sample of its audio.** "Hold a phone up to whatever's playing for 5–10 seconds, get back the chord chart, lyrics, and the rest of the map."
+
+That capability would extend PulseMap from "structured data about songs you already know" to "structured data you can find from a fragment." Concrete app categories it unlocks:
+
+- **Live-music education** — student plays a snippet, app shows the chord chart from that point onward.
+- **Busking aids** — pull up lyrics for whatever the band on the corner is playing right now.
+- **"Name that tune"** — gameplay around partial recognition.
+- **Classroom tools** — teacher plays a clip; lesson scaffolds appear synchronized.
+- **Accessibility** — synchronized captions / chord overlays on whatever is currently audible.
+- **Agent-driven "what's playing now"** — an agent with mic permission and a PulseMap library can answer the question structurally.
+
+This is the kind of capability that turns a protocol from interesting to indispensable, and it's a *natural* extension of work the schema already does (Chromaprint over the whole track) — just over windows.
+
+## Proposed schema addition
+
+Add a peer field on `PulseMapSchema`, alongside the existing `fingerprint`:
+
+```ts
+export const FingerprintWindowSchema = Type.Object({
+  t_start_ms: Type.Number(),
+  t_end_ms: Type.Number(),
+  chromaprint: Type.String({ description: "Base64-encoded Chromaprint over this window." }),
+  algorithm: Type.Number({ description: "Chromaprint algorithm version." }),
+});
+
+// inside PulseMapSchema:
+fingerprint_windows: Type.Optional(Type.Array(FingerprintWindowSchema)),
+```
+
+Output is **additive**: existing maps stay valid; the new field is optional. No major version bump required.
+
+**Suggested defaults** (subject to refinement during implementation):
+
+- Window size: ~10s — long enough for stable Chromaprint, short enough that any 5–10s sample lands inside or partially overlaps one.
+- Hop size: ~2s — overlapping windows. Trades index size for matcher robustness.
+- Algorithm: same Chromaprint version as the full-track print for consistency.
+
+A 4-minute song produces ~120 windows. Per-window Chromaprint is small (~hundreds of bytes), so the on-disk overhead is roughly 1× to 2× the existing single-print field.
+
+## Pipeline implications
+
+A new bootstrap stage runs Chromaprint on overlapping windows of the source audio. Two implementation paths:
+
+1. **Direct Chromaprint library bindings** (e.g. `pyacoustid`, `chromaprint-rs`). Far more efficient than shelling out to `fpcalc -length N -ts T` per window — we hold the audio buffer once and slide a Chromaprint over it.
+2. **`fpcalc` per window** — works, but ~120 process spawns per song is slow.
+
+Approach (1) is the recommended path. The stage is independent of the existing fingerprint stage and can run in parallel with other analysis.
+
+Re-running the pipeline on the existing 100+ map catalog is GPU-free and CPU-cheap relative to Demucs / WhisperX / torchcrepe — likely 5–10 minutes for the whole catalog.
+
+## Matching backend — the open question
+
+Schema and pipeline are the easy half. The harder half is **how a runtime client identifies a song from a captured snippet**. There are multiple valid approaches, and picking one is the load-bearing design decision this RFC is asking for help on.
+
+### Option A: brute-force scan
+
+For each candidate map in the catalog, slide the query fingerprint over the map's windows and score by Chromaprint Hamming similarity. Rank.
+
+- **Pro:** Trivially correct, easy to reason about, ships in a weekend.
+- **Pro:** Works at our current scale (~100 maps).
+- **Con:** Doesn't scale to thousands of maps in the browser. Doesn't scale at all to community-contributed maps without a server.
+- **Verdict:** Reasonable MVP. Insufficient long-term.
+
+### Option B: LSH / MinHash over Chromaprint chunks
+
+Index the chromaprint windows with locality-sensitive hashing — `audfprint`-style. Query becomes a near-constant-time hash lookup with candidate scoring.
+
+- **Pro:** Well-trodden ground in the audio fingerprinting literature.
+- **Pro:** Runs in the browser at modest catalog sizes.
+- **Con:** Tuning the hash bands and bin sizes is fiddly.
+- **Reference:** [audfprint](https://github.com/dpwe/audfprint), the academic literature around landmark fingerprinting.
+
+### Option C: vector index over learned embeddings
+
+Replace (or augment) Chromaprint with embeddings from an audio model (CLAP, MERT, etc.) and use FAISS / Annoy / Vespa.
+
+- **Pro:** State-of-the-art recall, especially against background noise / lossy capture.
+- **Con:** Requires a non-trivial ML dependency, an inference path on the client, and a separate index format. Departs from the protocol's "Chromaprint, period" stance.
+- **Verdict:** Promising as a successor but probably not the MVP.
+
+### Option D: re-use AcoustID infrastructure
+
+AcoustID already runs a global fingerprint database. Their endpoints are tuned for full-track matching. Could we extend or layer on top?
+
+- **Pro:** Existing global infrastructure, MusicBrainz integration we already use.
+- **Con:** Their model is full-track. They would have to extend.
+- **Verdict:** Worth a conversation with their team but not a starting point we can drive ourselves.
+
+### Option E: reference matcher service vs. client-side library
+
+Orthogonal to A–D. The matcher could be:
+
+- **Server:** PulseMap (or a community runner) hosts an endpoint that takes a fingerprint and returns a map id + offset. Adds infrastructure cost but keeps the catalog hot in memory.
+- **Client:** Ship the matching logic and the index format as a library; consumers download the index for the catalog they care about and run lookup locally.
+
+The client-side path aligns with PulseMap's "open data, no required service" ethos. The server-side path scales better past tens of thousands of maps.
+
+The right answer is probably "ship a client-side reference library AND let consumers run their own matcher service from the same code."
+
+## Privacy and licensing
+
+Chromaprint can run client-side. **Captured audio never needs to leave the user's device** — only the (small, non-reversible) fingerprint is sent for matching, if any matching happens off-device at all.
+
+This is a strong privacy story for the live-mic use cases (classroom, busking, agent observation) and worth stating explicitly in any consumer-facing UI built on top.
+
+## Open invitation
+
+This RFC is intentionally not a finished design. If you've worked on:
+
+- Audio fingerprinting (Chromaprint, audfprint, Shazam-style landmarks)
+- Approximate nearest-neighbor search (FAISS, Annoy, ScaNN, HNSW)
+- LSH / MinHash for high-dimensional retrieval
+- Audio embedding models (CLAP, MERT, etc.)
+- Real-time microphone capture for music recognition
+
+…this is exactly where to plug in. Open a discussion or comment on the issue tracking this RFC.
+
+## Tracking issue
+
+To be filed alongside the merge of this proposal.
+
+## Status / next steps
+
+1. Land this RFC as a draft.
+2. Open `good first issue`-flavored stubs for: pipeline stage implementation, MVP brute-force matcher, demo client (microphone → fingerprint → match → map view).
+3. Iterate on the matching backend choice based on contributor input before committing to schema.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "exports": {
     "./sdk": "./sdk/index.ts",
     "./sdk/adapters": "./sdk/adapters/index.ts",
-    "./schema": "./schema/map.ts"
+    "./schema": "./schema/map.ts",
+    "./schema/journey": "./schema/journey.ts"
   },
   "scripts": {
     "bootstrap": "bun run src/bootstrap/cli.ts",

--- a/schema/VERSIONING.md
+++ b/schema/VERSIONING.md
@@ -1,0 +1,50 @@
+# PulseMap versioning
+
+PulseMap follows **standard semver**, with **one source of truth**: the PulseMap package version *is* the schema version. There is one number for both.
+
+## What `version` means in a map file
+
+A map's top-level `version` field equals the PulseMap package version it was authored against:
+
+```json
+{
+  "version": "0.1.0",
+  "id": "0cdc9b5b-...",
+  "duration_ms": 243030
+}
+```
+
+When the PulseMap package releases `0.2.0`, new maps written from that point use `"version": "0.2.0"`. Existing maps are not rewritten — they continue to declare the version they were authored against.
+
+## Bump rules
+
+| Bump | What's allowed | What this implies for consumers |
+|---|---|---|
+| **Major** (`0.x → 1.0`, `1.x → 2.0`) | Breaking schema changes: removed fields, renamed fields, changed semantics, narrowed value spaces | Consumers must check `version` and may need to upgrade |
+| **Minor** (`0.1.x → 0.2.x`) | Additive only: new optional fields, new enum members in non-exhaustive positions | Same-major consumers continue to work; new fields are simply absent on older maps |
+| **Patch** (`0.1.0 → 0.1.1`) | No schema shape change. Implementation, doc, or pipeline fixes only | Consumers do not need to change anything |
+
+Same-major versions are forward-compatible for consumers: a `0.1.x` consumer reads any `0.1.y` map.
+
+## Pre-1.0 caveat
+
+PulseMap is alpha. Until `v1.0`, breaking changes can land in minor bumps if the alternative is shipping ugly long-term tradeoffs. We will document any such break clearly in the release notes and the CHANGELOG once that exists.
+
+## Journeys are out of scope
+
+PulseMap does not version journeys. Journey schemas live above this file in the layering:
+
+- The reference shapes in `schema/journey.ts` carry their own `version` field, which **PulseMap does not interpret**.
+- Journey authors are free to use whatever version system makes sense for their journey type — semver, dates, integers, freeform strings, or no version at all.
+- A breaking change in PulseMap (the map schema) does not break journeys, because journeys reference maps by id, not by structure.
+- A breaking change in your journey schema does not affect PulseMap.
+
+This separation is deliberate: it lets the journey ecosystem evolve faster than the map protocol without coupling.
+
+## How to record a breaking change
+
+Once we have a `CHANGELOG.md`, every breaking change goes there with:
+
+- The previous shape and the new shape (concrete examples, not just type signatures).
+- A migration path for existing data (one of: "no migration needed — additive," "consumers tolerate both," "tooling provided," "manual rewrite").
+- The PR that introduced it.

--- a/schema/journey.ts
+++ b/schema/journey.ts
@@ -1,0 +1,130 @@
+/**
+ * SUGGESTED REFERENCE SHAPE — not a controlled spec.
+ *
+ * PulseMap controls maps. Journeys are an open layer on top.
+ *
+ * You may use this type as-is, extend it, fork it, or define your own
+ * journey types and version systems entirely. PulseMap will not break
+ * your journey schema, because it does not own it. There is no
+ * compatibility commitment between this file and any consumer's
+ * journey storage.
+ *
+ * The shapes below reflect common cases — synchronized audio recording,
+ * pinned annotation, lesson sequence, lighting cue list — written down
+ * so consumers who want a starting point have one. The recording
+ * shape is informed by PulseGuide's lived implementation
+ * (https://github.com/hartphoenix/pulseguide), which currently uses
+ * its own local Journey type at version "0.2".
+ *
+ * This file is intentionally NOT re-exported from `pulsemap/sdk`.
+ * Authors who want this type import it explicitly from
+ * `pulsemap/schema/journey`.
+ */
+
+import { type Static, Type } from "@sinclair/typebox";
+
+/**
+ * Common fields every journey shares. The `version` field is open —
+ * pick whatever scheme makes sense for your journey type (semver, date,
+ * freeform). PulseMap will not interpret it.
+ */
+export const JourneyBaseSchema = Type.Object({
+	version: Type.String({
+		description: "Author-chosen version. PulseMap does not interpret this field.",
+	}),
+	id: Type.String({ description: "Stable journey id." }),
+	map_id: Type.String({
+		description: "PulseMap id this journey targets.",
+	}),
+	type: Type.String({
+		description:
+			"Discriminator. Reference shapes use 'recording', 'annotation', 'lesson', 'lighting'.",
+	}),
+	created_at: Type.String({ description: "ISO 8601 timestamp." }),
+});
+export type JourneyBase = Static<typeof JourneyBaseSchema>;
+
+/**
+ * Synchronized audio recording over a map. The PulseGuide reference
+ * implementation captures microphone audio while a map plays back,
+ * then renders it back in sync at view time.
+ *
+ * `playback_offset_ms` is additive: effective playback start =
+ * `start_offset_ms + playback_offset_ms`. Positive shifts the recording
+ * later in map-time, negative earlier. PulseGuide initializes this
+ * from `AudioContext.outputLatency` and lets users nudge by ear,
+ * clamped to ±2000.
+ */
+export const RecordingJourneySchema = Type.Composite([
+	JourneyBaseSchema,
+	Type.Object({
+		type: Type.Literal("recording"),
+		start_offset_ms: Type.Number({
+			description: "Map-time at recording start.",
+		}),
+		duration_ms: Type.Number(),
+		playback_offset_ms: Type.Number({
+			description: "Additive timing offset applied at playback. Suggested clamp ±2000.",
+		}),
+		audio: Type.Object({
+			mime: Type.String(),
+			uri: Type.Optional(Type.String()),
+			sha256: Type.Optional(Type.String()),
+		}),
+	}),
+]);
+export type RecordingJourney = Static<typeof RecordingJourneySchema>;
+
+/** Stub: a single text/markdown note pinned at a map-time. */
+export const AnnotationJourneySchema = Type.Composite([
+	JourneyBaseSchema,
+	Type.Object({
+		type: Type.Literal("annotation"),
+		t: Type.Number({ description: "Map-time in milliseconds." }),
+		text: Type.String(),
+		author: Type.Optional(Type.String()),
+	}),
+]);
+export type AnnotationJourney = Static<typeof AnnotationJourneySchema>;
+
+/** Stub: an ordered sequence of lesson steps keyed to map-time ranges. */
+export const LessonJourneySchema = Type.Composite([
+	JourneyBaseSchema,
+	Type.Object({
+		type: Type.Literal("lesson"),
+		steps: Type.Array(
+			Type.Object({
+				t_start: Type.Number(),
+				t_end: Type.Number(),
+				title: Type.String(),
+				body: Type.Optional(Type.String()),
+			}),
+		),
+	}),
+]);
+export type LessonJourney = Static<typeof LessonJourneySchema>;
+
+/**
+ * Stub: cue list for stage lighting / DMX / Hue. `cue` is an opaque
+ * payload — its shape is up to the lighting driver.
+ */
+export const LightingJourneySchema = Type.Composite([
+	JourneyBaseSchema,
+	Type.Object({
+		type: Type.Literal("lighting"),
+		cues: Type.Array(
+			Type.Object({
+				t: Type.Number(),
+				cue: Type.Unknown(),
+			}),
+		),
+	}),
+]);
+export type LightingJourney = Static<typeof LightingJourneySchema>;
+
+/**
+ * Convenience union of the reference shapes. Authors who define their
+ * own journey types should not include them in this union; build your
+ * own discriminated union in your own code.
+ */
+export type Journey = RecordingJourney | AnnotationJourney | LessonJourney | LightingJourney;


### PR DESCRIPTION
## Summary

PR 5 of the [demo-day legibility plan](../). Three additions, intentionally orthogonal to the runtime SDK.

### `schema/journey.ts` — suggested reference shape (not a controlled spec)

TypeBox-style file matching `schema/map.ts` conventions. Exports `JourneyBase` + four shape stubs: `RecordingJourney` (informed by [PulseGuide](https://github.com/hartphoenix/pulseguide)'s lived v0.2 implementation), `AnnotationJourney`, `LessonJourney`, `LightingJourney`.

The banner is unmistakable:

> PulseMap controls maps. Journeys are an open layer on top.
> You may use this type as-is, extend it, fork it, or define your own
> journey types and version systems entirely. PulseMap will not break
> your journey schema, because it does not own it.

Intentionally NOT re-exported from `sdk/index.ts` — that would imply ownership we don't claim. Consumers who want the starter type `import` it explicitly from `pulsemap/schema/journey`.

### `schema/VERSIONING.md` — unified semver, one source of truth

Half a page. The PulseMap package version *is* the schema version. Standard semver bump rules table. Pre-1.0 caveat. Explicit note that **PulseMap does not version journeys** — they live above this file in the layering, free to use whatever version system makes sense for the journey type.

### `docs/proposals/0001-windowed-fingerprints.md` — design RFC

A written proposal for partial-audio recognition (Shazam-shaped capability built into the protocol). Schema sketch (`fingerprint_windows` peer field, additive — no major bump), pipeline approach, four matching backend options (brute-force, LSH/MinHash, vector index, AcoustID extension), privacy posture (Chromaprint runs client-side; audio never leaves the device).

**No code shipped today.** The RFC's job is to articulate the open problem in enough detail that audience members with audio fingerprinting / ANN search / indexing background recognize a way in. This is the project's flagship recruitment artifact for the technical-builder slice of the demo audience.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (one Biome auto-fix; only formatting)
- [ ] Skim `schema/journey.ts` — does the SUGGESTED REFERENCE SHAPE banner read correctly?
- [ ] Skim `schema/VERSIONING.md` — is the journey carve-out clear?
- [ ] Skim the RFC — does the open invitation read like an invitation, not a TODO list?

## Follow-ups (not in this PR)

- Open a tracking issue: "deprecate `sdk/playback.ts` in favor of the adapter registry" (§5.3 — staged for the issue-creation batch).
- Open a `good first issue`: "implement the windowed-fingerprint pipeline stage per RFC 0001."
- Open a `good first issue`: "build a reference matcher service / library for windowed fingerprints."

🤖 Generated with [Claude Code](https://claude.com/claude-code)