### PR TITLE
chore: PR 48 polish — fix adapter-proposal issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/adapter-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/adapter-proposal.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Building an adapter for your own app does not require contributing it back. This template is for adapters you'd like to live upstream so others can use them.
 
-        **Before opening:** if your adapter is small and uncontroversial, you can skip this issue and just open a PR. See [`sdk/ADAPTERS.md`](../blob/main/sdk/ADAPTERS.md).
+        **Before opening:** if your adapter is small and uncontroversial, you can skip this issue and just open a PR. See [`sdk/ADAPTERS.md`](https://github.com/hartphoenix/pulsemap/blob/main/sdk/ADAPTERS.md).
 
   - type: input
     id: platform
@@ -54,7 +54,6 @@ body:
         - label: rate (variable speed)
         - label: volume
         - label: mute
-        - label: state events (play / pause / ended / buffering)
 
   - type: textarea
     id: caveats

--- a/sdk/ADAPTERS.md
+++ b/sdk/ADAPTERS.md
@@ -71,7 +71,7 @@ Methods for unsupported capabilities are safe to call but should no-op. Consumer
 
 Reference adapters in [`sdk/adapters/`](./adapters/) — copy one as a starting point. The two reference implementations (`YouTubeEmbedAdapter` and `HtmlAudioAdapter`) cover the two most common shapes: an iframe-with-message-bus platform and a direct DOM media element.
 
-The minimum viable adapter is around 50 lines of mostly-mechanical code:
+The minimum viable adapter is around 50 lines of mostly-mechanical code. **The skeleton below type-checks but is non-functional as-is** — `init()` and `play/pause/seek` are stubs, and `emit()` is never wired to the platform's events. To make it real you must (a) implement the bodies of `init`, `play`, `pause`, `seek`, `getPosition`, and (b) call `emit("playing" | "paused" | "ended" | "buffering")` from the platform's state callbacks. Both reference adapters in [`sdk/adapters/`](./adapters/) show what that wiring looks like.
 
 ```ts
 import type { PlaybackAdapter, AdapterMatcher, PlaybackState } from "pulsemap/sdk";


### PR DESCRIPTION
Three small fixes deferred from PR #48:

- **`adapter-proposal.yml`** — change relative URL to absolute. The `../blob/main/...` form doesn't resolve correctly in the rendered issue-form context.
- **`adapter-proposal.yml`** — drop the "state events" capability checkbox. `PlaybackCapabilitiesSchema` has no such field; the checkbox didn't map to anything.
- **`sdk/ADAPTERS.md`** — warn that the skeleton is non-functional as-is. It type-checks but never calls `emit()` and the method bodies are stubs. Without this note, a contributor pasting the skeleton ships a silent adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)