### PR TITLE
fix(editor): round map timestamps to integer ms on submission

### DIFF
--- a/editor/src/github/api.ts
+++ b/editor/src/github/api.ts
@@ -5,6 +5,7 @@
  */
 import type { PulseMap } from "pulsemap/schema";
 import { type DiffEntry, describeEntry, fieldCountsByLane, laneSummary } from "./diff";
+import { roundEntryTimestamps, roundMapTimestamps } from "./roundTimestamps";
 
 const UPSTREAM_OWNER = "hartphoenix";
 const UPSTREAM_REPO = "pulsemap";
@@ -108,7 +109,9 @@ export async function submitCorrection(
 	params: SubmitCorrectionParams,
 	onProgress?: ProgressCallback,
 ): Promise<SubmitCorrectionResult> {
-	const { token, mapId, map, entries, playbackAvailable, source } = params;
+	const { token, mapId, playbackAvailable, source } = params;
+	const map = roundMapTimestamps(params.map);
+	const entries = params.entries.map(roundEntryTimestamps);
 
 	const user = await ghJson<{ login: string }>("/user", token);
 	const username = user.login;

--- a/editor/src/github/roundTimestamps.ts
+++ b/editor/src/github/roundTimestamps.ts
@@ -1,0 +1,58 @@
+/**
+ * Round all millisecond timestamp fields in a map (and in diff entries)
+ * to integers before submission.
+ *
+ * Beat snapping and drag math produce float timestamps internally
+ * (e.g. 14806.437581380209). Schema-wise these are valid — `Type.Number()`
+ * doesn't require integers — but committing them produces noisy diffs,
+ * inflated JSON size, and floating-point churn on every re-save. The map
+ * format is millisecond-resolution by convention; sub-millisecond
+ * precision isn't carrying signal.
+ *
+ * This helper rounds at the submission boundary only. In-memory editor
+ * state is left untouched.
+ */
+
+import type { PulseMap } from "pulsemap/schema";
+import type { DiffEntry } from "./diff";
+
+const TIMESTAMP_KEYS = new Set(["t", "end", "t_start", "t_end", "duration_ms"]);
+
+function roundEvent<T extends Record<string, unknown>>(event: T): T {
+	const out: Record<string, unknown> = { ...event };
+	for (const key of Object.keys(out)) {
+		if (TIMESTAMP_KEYS.has(key) && typeof out[key] === "number") {
+			out[key] = Math.round(out[key] as number);
+		}
+	}
+	return out as T;
+}
+
+export function roundMapTimestamps(map: PulseMap): PulseMap {
+	const rounded: PulseMap = { ...map };
+	rounded.duration_ms = Math.round(map.duration_ms);
+	if (map.lyrics) rounded.lyrics = map.lyrics.map(roundEvent);
+	if (map.words) rounded.words = map.words.map(roundEvent);
+	if (map.chords) rounded.chords = map.chords.map(roundEvent);
+	if (map.beats) rounded.beats = map.beats.map(roundEvent);
+	if (map.sections) rounded.sections = map.sections.map(roundEvent);
+	return rounded;
+}
+
+export function roundEntryTimestamps(entry: DiffEntry): DiffEntry {
+	if (entry.kind === "field") {
+		const isTimestamp = TIMESTAMP_KEYS.has(entry.field);
+		if (isTimestamp && typeof entry.before === "number" && typeof entry.after === "number") {
+			return {
+				...entry,
+				before: Math.round(entry.before),
+				after: Math.round(entry.after),
+			};
+		}
+		return entry;
+	}
+	if (entry.value && typeof entry.value === "object") {
+		return { ...entry, value: roundEvent(entry.value as Record<string, unknown>) };
+	}
+	return entry;
+}


### PR DESCRIPTION
## Summary

Beat snapping and drag math produce float timestamps internally (e.g. \`14806.437581380209\`). Schema-wise they're valid (\`Type.Number()\` doesn't require integers), but committing them produces noisy diffs, inflated JSON size, and floating-point churn on every re-save.

This PR adds a \`roundTimestamps\` helper applied at the submission boundary only — in-memory editor state stays untouched, but the map JSON written to the PR and the structural diff in the PR body now both use integer milliseconds.

## Scope

- New file \`editor/src/github/roundTimestamps.ts\` with \`roundMapTimestamps\` and \`roundEntryTimestamps\`.
- Covers \`t\`, \`end\`, \`t_start\`, \`t_end\`, \`duration_ms\` across \`lyrics / words / chords / beats / sections\`.
- Applied in \`submitCorrection\` before serializing the map and before building the PR body.

## Test plan

- [x] \`bun run typecheck\` — clean (root + editor)
- [x] \`bun run lint\` — same pre-existing warnings, no new ones
- [ ] Submit a correction via the editor and verify the resulting PR body shows integer-only timestamps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)